### PR TITLE
Rename disabled parameters

### DIFF
--- a/DSCResources/MSFT_xDFSNamespaceFolder/MSFT_xDFSNamespaceFolder.psm1
+++ b/DSCResources/MSFT_xDFSNamespaceFolder/MSFT_xDFSNamespaceFolder.psm1
@@ -293,20 +293,20 @@ function Set-TargetResource
             }
 
             # Output the target parameters that were changed/set
-            $TargetProperties.GetEnumerator() | ForEach-Object -Process {                
+            $TargetProperties.GetEnumerator() | ForEach-Object -Process {
                 Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
                     $($LocalizedData.NamespaceFolderTargetUpdateParameterMessage) `
                         -f $Path,$TargetPath,$_.name, $_.value
-                ) -join '' )            
-            }            
+                ) -join '' )
+            }
         }
         else
         {
             # Prepare to use the PSBoundParameters as a splat to created
             # The new DFS Namespace Folder.
             $null = $PSBoundParameters.Remove('Ensure')
-                        
+
             # Correct the ReferralPriorityClass field
             if ($ReferralPriorityClass)
             { 
@@ -317,13 +317,13 @@ function Set-TargetResource
             $null = New-DfsnFolder `
                 @PSBoundParameters `
                 -ErrorAction Stop
-                                    
-            $PSBoundParameters.GetEnumerator() | ForEach-Object -Process {                
+
+            $PSBoundParameters.GetEnumerator() | ForEach-Object -Process {
                 Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
                     $($LocalizedData.NamespaceFolderUpdateParameterMessage) `
                         -f $Path,$TargetPath,$_.name, $_.value
-                ) -join '' )            
+                ) -join '' )
             }
         }
     }
@@ -335,8 +335,8 @@ function Set-TargetResource
         $Target = Get-FolderTarget `
             -Path $Path `
             -TargetPath $TargetPath
-            
-        if ($Target)                
+
+        if ($Target)
         {
             # Remove the target from the Namespace Folder
             $null = Remove-DfsnFolderTarget `
@@ -350,7 +350,7 @@ function Set-TargetResource
                 $($LocalizedData.NamespaceFolderTargetRemovedMessage) `
                     -f $Path,$TargetPath
             ) -join '' )
-        }            
+        }
     }
 } # Set-TargetResource
 

--- a/DSCResources/MSFT_xDFSReplicationGroup/MSFT_xDFSReplicationGroup.psm1
+++ b/DSCResources/MSFT_xDFSReplicationGroup/MSFT_xDFSReplicationGroup.psm1
@@ -350,7 +350,7 @@ function Set-TargetResource
                         $ReplicationGroupConnection = Get-DfsrConnection @Splat `
                             -ErrorAction Stop
                         if ($ReplicationGroupConnection) {
-                            if ($ReplicationGroupConnection.DisableConnection) {
+                            if (-not $ReplicationGroupConnection.Enabled) {
                                 Set-DfsrConnection @Splat `
                                     -DisableConnection $false `
                                     -ErrorAction Stop
@@ -572,7 +572,7 @@ function Test-TargetResource
                                 -ErrorAction Stop
                             if ($ReplicationGroupConnection)
                             {
-                                if ($ReplicationGroupConnection.DisableConnection)
+                                if (-not $ReplicationGroupConnection.Enabled)
                                 {
                                     Write-Verbose -Message ( @(
                                         "$($MyInvocation.MyCommand): "

--- a/DSCResources/MSFT_xDFSReplicationGroupConnection/MSFT_xDFSReplicationGroupConnection.schema.mof
+++ b/DSCResources/MSFT_xDFSReplicationGroupConnection/MSFT_xDFSReplicationGroupConnection.schema.mof
@@ -6,7 +6,7 @@ class MSFT_xDFSReplicationGroupConnection : OMI_BaseResource
     [Key, Description("The DFS Replication Group connection destination computer name.")] String DestinationComputerName;
     [Required, Description("Specifies whether the DSF Replication Group connection should exist."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("A description for the DFS Replication Group connection.")] String Description;
-    [Write, Description("Disable the Replication Group connection.")] Boolean DisableConnection;
-    [Write, Description("Disable remote differential compression on the Replication Group connection.")] Boolean DisableRDC;
+    [Write, Description("Ensures that connection is either Enabled or Disabled."),ValueMap{"Enabled","Disabled"}, Values{"Enabled","Disabled"}] String EnsureEnabled;
+    [Write, Description("Ensures remote differential compression is Enabled or Disabled."),ValueMap{"Enabled","Disabled"}, Values{"Enabled","Disabled"}] String EnsureRDCEnabled;
     [Write, Description("The name of the AD Domain the DFS Replication Group connection should be in.")] String DomainName;
 };

--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Configuration DFSNamespace_Standalone_Public
 * RepGroup renamed to ReplicationGroup in all files.
 * xDFSReplicationGroupConnection- Changed DisableConnection parameter to EnsureEnabled.
                                   Changed DisableRDC parameter to EnsureRDCEnabled.
+* xDFSReplicationGroup- Fixed bug where disabled connection was not enabled in Fullmesh topology.
 
 ### 2.2.0.0
 * DSC Module moved to MSFT.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This resource is used to create, edit or remove DFS Replication Groups. If used 
 
 #### Parameters
 * **GroupName**: The name of the Replication Group. Required.
-* **Ensure**: Ensures that Replication Group is either Absent or Present. Required.
+* **Ensure**: Ensures that Replication Group is either Absent or Present. Required. { Absent | Present }
 * **Description**: A description for the Replication Group. Optional.
 * **Members**: A list of computers that are members of this Replication Group. These can be specified using either the ComputerName or FQDN name for each member. If an FQDN name is used and the DomainName parameter is set, the FQDN domain name must match. Optional.
 * **Folders**: A list of folders that are replicated in this Replication Group. Optional.
@@ -46,12 +46,12 @@ This resource is used to create, edit and remove DFS Replication Group connectio
 
 #### Parameters
 * **GroupName**: The name of the Replication Group. Required.
-* **Ensure**: Ensures that Replication Group connection is either Absent or Present. Required.
+* **Ensure**: Ensures that Replication Group connection is either Absent or Present. Required. { Absent | Present }
 * **SourceComputerName**: The name of the Replication Group source computer for the connection. This can be specified using either the ComputerName or FQDN name for the member. If an FQDN name is used and the DomainName parameter is set, the FQDN domain name must match. Required.
 * **DestinationComputerName**: The name of the Replication Group destination computer for the connection. This can be specified using either the ComputerName or FQDN name for the member. If an FQDN name is used and the DomainName parameter is set, the FQDN domain name must match. Required.
 * **Description**: A description for the Replication Group connection. Optional.
-* **DisableConnection**: Set to $true to disable this connection. Optional.
-* **RDCDisable**: Set to $true to disable remote differental compression on this connection. Optional.
+* **EnsureEnabled**: Ensures that connection is either Enabled or Disabled. Optional. { Enabled | Disabled }. Default: Enabled.
+* **EnsureRDCEnabled**: Ensures remote differential compression is Enabled or Disabled. Optional.  { Enabled | Disabled }. Default: Enabled.
 * **DomainName**: The AD domain the Replication Group connection should created in. Optional.
 
 ### xDFSReplicationGroupFolder
@@ -507,6 +507,8 @@ Configuration DFSNamespace_Standalone_Public
 ## Versions
 ### 3.0.0.0
 * RepGroup renamed to ReplicationGroup in all files.
+* xDFSReplicationGroupConnection- Changed DisableConnection parameter to EnsureEnabled.
+                                  Changed DisableRDC parameter to EnsureRDCEnabled.
 
 ### 2.2.0.0
 * DSC Module moved to MSFT.

--- a/Tests/Unit/MSFT_xDFSReplicationGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xDFSReplicationGroup.Tests.ps1
@@ -121,8 +121,8 @@ try
                 DestinationComputerName = $ReplicationGroup.Members[1]
                 Ensure = 'Present'
                 Description = 'Connection Description'
-                DisableConnection = $false
-                DisableRDC = $false
+                EnsureEnabled = 'Enabled'
+                EnsureRDCEnabled = 'Enabled'
                 DomainName = 'CONTOSO.COM'
             },
             [PSObject]@{
@@ -131,13 +131,13 @@ try
                 DestinationComputerName = $ReplicationGroup.Members[0]
                 Ensure = 'Present'
                 Description = 'Connection Description'
-                DisableConnection = $false
-                DisableRDC = $false
+                EnsureEnabled = 'Enabled'
+                EnsureRDCEnabled = 'Enabled'
                 DomainName = 'CONTOSO.COM'
             }
         )
         $ReplicationGroupConnectionDisabled = $ReplicationGroupConnections[0].Clone()
-        $ReplicationGroupConnectionDisabled.DisableConnection = $True
+        $ReplicationGroupConnectionDisabled.EnsureEnabled = 'Disabled'
         $MockReplicationGroup = [PSObject]@{
             GroupName = $ReplicationGroup.GroupName
             DomainName = $ReplicationGroup.DomainName
@@ -194,8 +194,8 @@ try
             SourceComputerName = $ReplicationGroupConnections[0].SourceComputerName
             DestinationComputerName = $ReplicationGroupConnections[0].DestinationComputerName
             Description = $ReplicationGroupConnections[0].Description
-            Enabled = (-not $ReplicationGroupConnections[0].DisableConnection)
-            RDCEnabled = (-not $ReplicationGroupConnections[0].DisableRDC)
+            Enabled = ($ReplicationGroupConnections[0].EnsureEnabled -eq 'Enabled')
+            RDCEnabled = ($ReplicationGroupConnections[0].EnsureRDCEnabled -eq 'Enabled')
             DomainName = $ReplicationGroupConnections[0].DomainName
         }
         $ReplicationGroupContentPath = $ReplicationGroup.Clone()

--- a/Tests/Unit/MSFT_xDFSReplicationGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xDFSReplicationGroup.Tests.ps1
@@ -189,15 +189,26 @@ try
         $MockReplicationGroupMembershipNotPrimary = $MockReplicationGroupMembership.Clone()
         $MockReplicationGroupMembershipNotPrimary.PrimaryMember = $False
     
-        $MockReplicationGroupConnection = [PSObject]@{
-            GroupName = $ReplicationGroupConnections[0].GroupName
-            SourceComputerName = $ReplicationGroupConnections[0].SourceComputerName
-            DestinationComputerName = $ReplicationGroupConnections[0].DestinationComputerName
-            Description = $ReplicationGroupConnections[0].Description
-            Enabled = ($ReplicationGroupConnections[0].EnsureEnabled -eq 'Enabled')
-            RDCEnabled = ($ReplicationGroupConnections[0].EnsureRDCEnabled -eq 'Enabled')
-            DomainName = $ReplicationGroupConnections[0].DomainName
-        }
+        $MockReplicationGroupConnections = @(
+            [PSObject]@{
+                GroupName = $ReplicationGroupConnections[0].GroupName
+                SourceComputerName = $ReplicationGroupConnections[0].SourceComputerName
+                DestinationComputerName = $ReplicationGroupConnections[0].DestinationComputerName
+                Description = $ReplicationGroupConnections[0].Description
+                Enabled = ($ReplicationGroupConnections[0].EnsureEnabled -eq 'Enabled')
+                RDCEnabled = ($ReplicationGroupConnections[0].EnsureRDCEnabled -eq 'Enabled')
+                DomainName = $ReplicationGroupConnections[0].DomainName
+            },
+            [PSObject]@{
+                GroupName = $ReplicationGroupConnections[1].GroupName
+                SourceComputerName = $ReplicationGroupConnections[1].SourceComputerName
+                DestinationComputerName = $ReplicationGroupConnections[1].DestinationComputerName
+                Description = $ReplicationGroupConnections[1].Description
+                Enabled = ($ReplicationGroupConnections[1].EnsureEnabled -eq 'Enabled')
+                RDCEnabled = ($ReplicationGroupConnections[1].EnsureRDCEnabled -eq 'Enabled')
+                DomainName = $ReplicationGroupConnections[1].DomainName
+            }
+        )
         $MockReplicationGroupConnectionDisabled = [PSObject]@{
             GroupName = $ReplicationGroupConnections[0].GroupName
             SourceComputerName = $ReplicationGroupConnections[0].SourceComputerName
@@ -599,7 +610,7 @@ try
                     Assert-MockCalled -commandName Remove-DfsReplicatedFolder -Exactly 0
                 }
             }
-    
+
             Context 'Replication Group with Fullmesh topology exists and is correct' {
                 
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
@@ -612,11 +623,19 @@ try
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
                 Mock New-DfsReplicatedFolder
                 Mock Remove-DfsReplicatedFolder
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[0]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[1]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
+                Mock Get-DfsrConnection `
+                    -MockWith { @($MockReplicationGroupConnections[0]) } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)"
+                    }
+                Mock Get-DfsrConnection `
+                    -MockWith { @($MockReplicationGroupConnections[1]) } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)"
+                    }
                 Mock Add-DfsrConnection
                 Mock Set-DfsrConnection
-    
+
                 It 'should not throw error' {
                     { 
                         $Splat = $ReplicationGroup.Clone()
@@ -653,11 +672,19 @@ try
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
                 Mock New-DfsReplicatedFolder
                 Mock Remove-DfsReplicatedFolder
-                Mock Get-DfsrConnection -MockWith { } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[1]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
+                Mock Get-DfsrConnection `
+                    -MockWith { } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)"
+                    }
+                Mock Get-DfsrConnection `
+                    -MockWith { @($MockReplicationGroupConnections[1]) } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)"
+                    }
                 Mock Add-DfsrConnection
                 Mock Set-DfsrConnection
-    
+
                 It 'should not throw error' {
                     { 
                         $Splat = $ReplicationGroup.Clone()
@@ -694,13 +721,21 @@ try
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
                 Mock New-DfsReplicatedFolder
                 Mock Remove-DfsReplicatedFolder
-                Mock Get-DfsrConnection -MockWith { } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
-                Mock Get-DfsrConnection -MockWith { } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
+                Mock Get-DfsrConnection `
+                    -MockWith { } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)"
+                    }
+                Mock Get-DfsrConnection `
+                    -MockWith { } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)"
+                    }
                 Mock Add-DfsrConnection
                 Mock Set-DfsrConnection
-    
+
                 It 'should not throw error' {
-                    { 
+                    {
                         $Splat = $ReplicationGroup.Clone()
                         $Splat.Topology = 'Fullmesh'
                         Set-TargetResource @Splat
@@ -722,9 +757,8 @@ try
                     Assert-MockCalled -commandName Set-DfsrConnection -Exactly 0
                 }
             }
-    
+
             Context 'Replication Group with Fullmesh topology exists and has a disabled connection' {
-                
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock New-DfsReplicationGroup
                 Mock Set-DfsReplicationGroup
@@ -735,11 +769,19 @@ try
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
                 Mock New-DfsReplicatedFolder
                 Mock Remove-DfsReplicatedFolder
-                Mock Get-DfsrConnection -MockWith { return $MockReplicationGroupConnectionDisabled } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[1]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
+                Mock Get-DfsrConnection `
+                    -MockWith { return $MockReplicationGroupConnectionDisabled } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)"
+                    }
+                Mock Get-DfsrConnection `
+                    -MockWith { @($MockReplicationGroupConnections[1]) } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)"
+                    }
                 Mock Add-DfsrConnection
                 Mock Set-DfsrConnection
-    
+
                 It 'should not throw error' {
                     { 
                         $Splat = $ReplicationGroup.Clone()
@@ -763,7 +805,7 @@ try
                     Assert-MockCalled -commandName Set-DfsrConnection -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group Content Path is set but needs to be changed' {
                 
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
@@ -778,7 +820,7 @@ try
                 Mock Remove-DfsReplicatedFolder
                 Mock Get-DfsrMembership -MockWith { @($MockReplicationGroupMembership) }
                 Mock Set-DfsrMembership
-    
+
                 It 'should not throw error' {
                     { 
                         $Splat = $ReplicationGroupContentPath.Clone()
@@ -801,9 +843,9 @@ try
                     Assert-MockCalled -commandName Set-DfsrMembership -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group Content Path is set and does not need to be changed' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock New-DfsReplicationGroup
                 Mock Set-DfsReplicationGroup
@@ -816,7 +858,7 @@ try
                 Mock Remove-DfsReplicatedFolder
                 Mock Get-DfsrMembership -MockWith { @($MockReplicationGroupMembership) }
                 Mock Set-DfsrMembership
-    
+
                 It 'should not throw error' {
                     { 
                         $Splat = $ReplicationGroupContentPath.Clone()
@@ -838,9 +880,9 @@ try
                     Assert-MockCalled -commandName Set-DfsrMembership -Exactly 0
                 }
             }
-    
+
             Context 'Replication Group Content Path is set and does not need to be changed but primarymember does' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock New-DfsReplicationGroup
                 Mock Set-DfsReplicationGroup
@@ -853,7 +895,7 @@ try
                 Mock Remove-DfsReplicatedFolder
                 Mock Get-DfsrMembership -MockWith { @($MockReplicationGroupMembershipNotPrimary) }
                 Mock Set-DfsrMembership
-    
+
                 It 'should not throw error' {
                     { 
                         $Splat = $ReplicationGroupContentPath.Clone()
@@ -876,18 +918,17 @@ try
                 }
             }
         }
-    
+
         Describe "$($Global:DSCResourceName)\Test-TargetResource" {
             Context 'Replication Group does not exist but should' {
-                
+
                 Mock Get-DfsReplicationGroup
                 Mock Get-DfsrMember
                 Mock Get-DfsReplicatedFolder
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     Test-TargetResource @Splat | Should Be $False
-                    
                 }
                 It 'should call expected Mocks' {
                     Assert-MockCalled -commandName Get-DfsReplicationGroup -Exactly 1
@@ -895,13 +936,13 @@ try
                     Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly 0
                 }
             }
-    
+
             Context 'Replication Group exists but has different description' {
                 
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Description = 'Changed'
@@ -913,13 +954,13 @@ try
                     Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group exists but all Members passed as FQDN' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroupAllFQDN.Clone()
                     Test-TargetResource @Splat | Should Be $True
@@ -936,7 +977,7 @@ try
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroupSomeDns.Clone()
                     Test-TargetResource @Splat | Should Be $True
@@ -953,7 +994,7 @@ try
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Members = @('FileServer2','FileServer1','FileServerNew')
@@ -965,13 +1006,13 @@ try
                     Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group exists but has an extra member' {
                 
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Members = @('FileServer2')
@@ -983,13 +1024,13 @@ try
                     Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group exists but is missing a folder' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Folders = @('Folder2','Folder1','FolderNew')
@@ -1001,13 +1042,13 @@ try
                     Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group exists but has an extra folder' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Folders = @('Folder2')
@@ -1024,7 +1065,7 @@ try
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Ensure = 'Absent'
@@ -1036,13 +1077,13 @@ try
                     Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly 0
                 }
             }
-    
+
             Context 'Replication Group exists and is correct' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-    
+
                 It 'should return true' {
                     $Splat = $ReplicationGroup.Clone()
                     Test-TargetResource @Splat | Should Be $True
@@ -1053,15 +1094,23 @@ try
                     Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group Fullmesh Topology is required and correct' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[0]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[1]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
-    
+                Mock Get-DfsrConnection `
+                    -MockWith { @($MockReplicationGroupConnections[0]) } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)"
+                    }
+                Mock Get-DfsrConnection `
+                    -MockWith { @($MockReplicationGroupConnections[1]) } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)"
+                    }
+
                 It 'should return true' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Topology = 'Fullmesh'
@@ -1074,15 +1123,23 @@ try
                     Assert-MockCalled -commandName Get-DfsrConnection -Exactly 2
                 }
             }
-    
+
             Context 'Replication Group Fullmesh Topology is required and one connection missing' {
                 
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[0]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
-                Mock Get-DfsrConnection -MockWith { } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
-    
+                Mock Get-DfsrConnection `
+                    -MockWith { @($MockReplicationGroupConnections[0]) } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)"
+                    }
+                Mock Get-DfsrConnection `
+                    -MockWith { } `
+                    -ParameterFilter { `
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)"
+                    }
+
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Topology = 'Fullmesh'
@@ -1095,15 +1152,22 @@ try
                     Assert-MockCalled -commandName Get-DfsrConnection -Exactly 2
                 }
             }
-    
+
             Context 'Replication Group Fullmesh Topology is required and all connections missing' {
                 
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-                Mock Get-DfsrConnection -MockWith { } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
-                Mock Get-DfsrConnection -MockWith { } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
-    
+                Mock Get-DfsrConnection `
+                    -MockWith { } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)"
+                    }
+                Mock Get-DfsrConnection `
+                    -MockWith { } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)"
+                    }
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Topology = 'Fullmesh'
@@ -1116,15 +1180,22 @@ try
                     Assert-MockCalled -commandName Get-DfsrConnection -Exactly 2
                 }
             }
-    
+
             Context 'Replication Group Fullmesh Topology is required and connection is disabled' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-                Mock Get-DfsrConnection -MockWith {  return $MockReplicationGroupConnectionDisabled } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[1]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
-    
+                Mock Get-DfsrConnection `
+                    -MockWith { return $MockReplicationGroupConnectionDisabled } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)"
+                    }
+                Mock Get-DfsrConnection `
+                    -MockWith { @($MockReplicationGroupConnections[1]) } `
+                    -ParameterFilter {
+                        $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)"
+                    }
                 It 'should return false' {
                     $Splat = $ReplicationGroup.Clone()
                     $Splat.Topology = 'Fullmesh'
@@ -1137,14 +1208,14 @@ try
                     Assert-MockCalled -commandName Get-DfsrConnection -Exactly 2
                 }
             }
-    
+
             Context 'Replication Group Content Path is set and different' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
                 Mock Get-DfsrMembership -MockWith { @($MockReplicationGroupMembership) }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroupContentPath.Clone()
                     $Splat.ContentPaths = @('Different')
@@ -1157,14 +1228,14 @@ try
                     Assert-MockCalled -commandName Get-DfsrMembership -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group Content Path is set and the same and PrimaryMember is correct' {
-                
+
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
                 Mock Get-DfsrMembership -MockWith { @($MockReplicationGroupMembership) }
-    
+
                 It 'should return true' {
                     $Splat = $ReplicationGroupContentPath.Clone()
                     Test-TargetResource @Splat | Should Be $True
@@ -1176,17 +1247,16 @@ try
                     Assert-MockCalled -commandName Get-DfsrMembership -Exactly 1
                 }
             }
-    
+
             Context 'Replication Group Content Path is set and the same and PrimaryMember is not correct' {
                 
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
                 Mock Get-DfsrMembership -MockWith { @($MockReplicationGroupMembershipNotPrimary) }
-    
+
                 It 'should return false' {
                     $Splat = $ReplicationGroupContentPath.Clone()
-    
                     Test-TargetResource @Splat | Should Be $False
                 }
                 It 'should call expected Mocks' {
@@ -1206,9 +1276,9 @@ try
                         ComputerName = 'test.contoso.com'
                         DomainName = 'CONTOSO.COM'
                     }
-                    Get-FQDNMemberName @Splat | Should Be 'test.contoso.com'         
+                    Get-FQDNMemberName @Splat | Should Be 'test.contoso.com'
                 }
-            }    
+            }
             Context 'ComputerName passed includes Domain Name that does not match DomainName' {
                 It 'should throw ReplicationGroupDomainMismatchError exception' {
                     $Splat = @{
@@ -1223,9 +1293,9 @@ try
                             -f $Splat.GroupName,$Splat.ComputerName,$Splat.DomainName)
                     }
                     $Exception = New-TestException @ExceptionParameters
-                    { Get-FQDNMemberName @Splat } | Should Throw $Exception         
+                    { Get-FQDNMemberName @Splat } | Should Throw $Exception
                 }
-            }    
+            }
             Context 'ComputerName passed does not include Domain Name and DomainName was passed' {
                 It 'should return correct FQDN' {
                     $Splat = @{
@@ -1233,18 +1303,18 @@ try
                         ComputerName = 'test'
                         DomainName = 'CONTOSO.COM'
                     }
-                    Get-FQDNMemberName @Splat | Should Be 'test.contoso.com'         
+                    Get-FQDNMemberName @Splat | Should Be 'test.contoso.com'
                 }
-            }    
+            }
             Context 'ComputerName passed does not include Domain Name and DomainName was not passed' {
                 It 'should return correct FQDN' {
                     $Splat = @{
                         GroupName = 'UnitTest'
                         ComputerName = 'test'
                     }
-                    Get-FQDNMemberName @Splat | Should Be 'test'         
+                    Get-FQDNMemberName @Splat | Should Be 'test'
                 }
-            }    
+            }
         }
     }
     #endregion

--- a/Tests/Unit/MSFT_xDFSReplicationGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xDFSReplicationGroup.Tests.ps1
@@ -198,6 +198,15 @@ try
             RDCEnabled = ($ReplicationGroupConnections[0].EnsureRDCEnabled -eq 'Enabled')
             DomainName = $ReplicationGroupConnections[0].DomainName
         }
+        $MockReplicationGroupConnectionDisabled = [PSObject]@{
+            GroupName = $ReplicationGroupConnections[0].GroupName
+            SourceComputerName = $ReplicationGroupConnections[0].SourceComputerName
+            DestinationComputerName = $ReplicationGroupConnections[0].DestinationComputerName
+            Description = $ReplicationGroupConnections[0].Description
+            Enabled = $False
+            RDCEnabled = ($ReplicationGroupConnections[0].EnsureRDCEnabled -eq 'Enabled')
+            DomainName = $ReplicationGroupConnections[0].DomainName
+        }
         $ReplicationGroupContentPath = $ReplicationGroup.Clone()
         $ReplicationGroupContentPath += @{ ContentPaths = @($MockReplicationGroupMembership.ContentPath) }
     
@@ -726,7 +735,7 @@ try
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
                 Mock New-DfsReplicatedFolder
                 Mock Remove-DfsReplicatedFolder
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnectionDisabled) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
+                Mock Get-DfsrConnection -MockWith { return $MockReplicationGroupConnectionDisabled } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
                 Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[1]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
                 Mock Add-DfsrConnection
                 Mock Set-DfsrConnection
@@ -1113,7 +1122,7 @@ try
                 Mock Get-DfsReplicationGroup -MockWith { @($MockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $MockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $MockReplicationGroupFolder }
-                Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnectionDisabled) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
+                Mock Get-DfsrConnection -MockWith {  return $MockReplicationGroupConnectionDisabled } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[0].SourceComputerName).$($ReplicationGroupConnections[0].DomainName)" }
                 Mock Get-DfsrConnection -MockWith { @($ReplicationGroupConnections[1]) } -ParameterFilter { $SourceComputerName -eq "$($ReplicationGroupConnections[1].SourceComputerName).$($ReplicationGroupConnections[1].DomainName)" }
     
                 It 'should return false' {

--- a/Tests/Unit/MSFT_xDFSReplicationGroupConnection.Tests.ps1
+++ b/Tests/Unit/MSFT_xDFSReplicationGroupConnection.Tests.ps1
@@ -80,8 +80,8 @@ try
                 DestinationComputerName = $ReplicationGroup.Members[1]
                 Ensure = 'Present'
                 Description = 'Connection Description'
-                DisableConnection = $false
-                DisableRDC = $false
+                EnsureEnabled = 'Enabled'
+                EnsureRDCEnabled = 'Enabled'
                 DomainName = 'CONTOSO.COM'
             },
             [PSObject]@{
@@ -90,13 +90,13 @@ try
                 DestinationComputerName = $ReplicationGroup.Members[0]
                 Ensure = 'Present'
                 Description = 'Connection Description'
-                DisableConnection = $false
-                DisableRDC = $false
+                EnsureEnabled = 'Enabled'
+                EnsureRDCEnabled = 'Enabled'
                 DomainName = 'CONTOSO.COM'
             }
         )
         $ReplicationGroupConnectionDisabled = $ReplicationGroupConnections[0].Clone()
-        $ReplicationGroupConnectionDisabled.DisableConnection = $True
+        $ReplicationGroupConnectionDisabled.EnsureEnabled = 'Disabled'
         $MockReplicationGroup = [PSObject]@{
             GroupName = $ReplicationGroup.GroupName
             DomainName = $ReplicationGroup.DomainName
@@ -149,8 +149,8 @@ try
             SourceComputerName = $ReplicationGroupConnections[0].SourceComputerName
             DestinationComputerName = $ReplicationGroupConnections[0].DestinationComputerName
             Description = $ReplicationGroupConnections[0].Description
-            Enabled = (-not $ReplicationGroupConnections[0].DisableConnection)
-            RDCEnabled = (-not $ReplicationGroupConnections[0].DisableRDC)
+            Enabled = ($ReplicationGroupConnections[0].EnsureEnabled -eq 'Enabled')
+            RDCEnabled = ($ReplicationGroupConnections[0].EnsureRDCEnabled -eq 'Enabled')
             DomainName = $ReplicationGroupConnections[0].DomainName
         }
     
@@ -188,8 +188,8 @@ try
                     $Result.SourceComputerName | Should Be $ReplicationGroupConnections[0].SourceComputerName
                     $Result.DestinationComputerName | Should Be $ReplicationGroupConnections[0].DestinationComputerName
                     $Result.Description | Should Be $ReplicationGroupConnections[0].Description
-                    $Result.DisableConnection | Should Be $ReplicationGroupConnections[0].DisableConnection
-                    $Result.DisableRDC | Should Be $ReplicationGroupConnections[0].DisableRDC
+                    $Result.EnsureEnabled | Should Be $ReplicationGroupConnections[0].EnsureEnabled
+                    $Result.EnsureRDCEnabled | Should Be $ReplicationGroupConnections[0].EnsureRDCEnabled
                     $Result.DomainName | Should Be $ReplicationGroupConnections[0].DomainName
                 }
                 It 'should call the expected mocks' {
@@ -212,8 +212,8 @@ try
                     $Result.SourceComputerName | Should Be $ReplicationGroupConnections[0].SourceComputerName
                     $Result.DestinationComputerName | Should Be $ReplicationGroupConnections[0].DestinationComputerName
                     $Result.Description | Should Be $ReplicationGroupConnections[0].Description
-                    $Result.DisableConnection | Should Be $ReplicationGroupConnections[0].DisableConnection
-                    $Result.DisableRDC | Should Be $ReplicationGroupConnections[0].DisableRDC
+                    $Result.EnsureEnabled | Should Be $ReplicationGroupConnections[0].EnsureEnabled
+                    $Result.EnsureRDCEnabled | Should Be $ReplicationGroupConnections[0].EnsureRDCEnabled
                     $Result.DomainName | Should Be $ReplicationGroupConnections[0].DomainName
                 }
                 It 'should call the expected mocks' {
@@ -311,7 +311,7 @@ try
                 }
             }
     
-            Context 'Replication Group connection exists but has different DisableConnection' {
+            Context 'Replication Group connection exists but has different EnsureEnabled' {
                 
                 Mock Get-DfsrConnection -MockWith { return @($MockReplicationGroupConnection) }
                 Mock Set-DfsrConnection
@@ -321,7 +321,7 @@ try
                 It 'should not throw error' {
                     { 
                         $Splat = $ReplicationGroupConnections[0].Clone()
-                        $Splat.DisableConnection = (-not $Splat.DisableConnection)
+                        $Splat.EnsureEnabled = 'Disabled'
                         Set-TargetResource @Splat
                     } | Should Not Throw
                 }
@@ -333,7 +333,7 @@ try
                 }
             }
     
-            Context 'Replication Group connection exists but has different DisableRDC' {
+            Context 'Replication Group connection exists but has different EnsureRDCEnabled' {
                 
                 Mock Get-DfsrConnection -MockWith { return @($MockReplicationGroupConnection) }
                 Mock Set-DfsrConnection
@@ -343,7 +343,7 @@ try
                 It 'should not throw error' {
                     { 
                         $Splat = $ReplicationGroupConnections[0].Clone()
-                        $Splat.DisableRDC = (-not $Splat.DisableRDC)
+                        $Splat.EnsureRDCEnabled = 'Disabled'
                         $Splat.Description = 'Changed'
                         Set-TargetResource @Splat
                     } | Should Not Throw
@@ -458,13 +458,13 @@ try
                 }
             }
     
-            Context 'Replication Group Connection exists but has different DisableConnection' {
+            Context 'Replication Group Connection exists but has different EnsureEnabled' {
                 
                 Mock Get-DfsrConnection -MockWith { @($MockReplicationGroupConnection) }
     
                 It 'should return false' {
                     $Splat = $ReplicationGroupConnections[0].Clone()
-                    $Splat.DisableConnection = (-not $Splat.DisableConnection)
+                    $Splat.EnsureEnabled = 'Disabled'
                     Test-TargetResource @Splat | Should Be $False
                 }
                 It 'should call expected Mocks' {
@@ -472,13 +472,13 @@ try
                 }
             }
     
-            Context 'Replication Group Connection exists but has different DisableRDC' {
+            Context 'Replication Group Connection exists but has different EnsureRDCEnabled' {
                 
                 Mock Get-DfsrConnection -MockWith { @($MockReplicationGroupConnection) }
     
                 It 'should return false' {
                     $Splat = $ReplicationGroupConnections[0].Clone()
-                    $Splat.DisableRDC = (-not $Splat.DisableRDC)
+                    $Splat.EnsureRDCEnabled = 'Disabled'
                     Test-TargetResource @Splat | Should Be $False
                 }
                 It 'should call expected Mocks' {


### PR DESCRIPTION
- xDFSReplicationGroupConnection- Changed DisableConnection parameter to EnsureEnabled.
                                Changed DisableRDC parameter to EnsureRDCEnabled.
- xDFSReplicationGroup- Fixed bug where disabled connection was not enabled in Fullmesh topology.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/xdfs/8)

<!-- Reviewable:end -->
