### PR TITLE
Removed Pester version number from AppVeyor.yml - Fixes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,9 @@ Start-DscConfiguration `
 ```
 
 ## Versions
+### Unreleased
+* Removed Pester version from AppVeyor.yml.
+
 ### 3.0.0.0
 * RepGroup renamed to ReplicationGroup in all files.
 * xDFSReplicationGroupConnection- Changed DisableConnection parameter to EnsureEnabled.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 os: WMF 5
 version: 3.0.{build}.0
 install:
-  - cinst -y pester --version 3.3.13
+  - cinst -y pester
   - git clone https://github.com/PowerShell/DscResource.Tests
   - ps: Push-Location
   - cd DscResource.Tests


### PR DESCRIPTION
Pester version number in AppVeyor not required so this PR removes it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdfs/14)

<!-- Reviewable:end -->
