### PR TITLE
Fix xDFSNamespaceServerConfiguration tests - Fixes #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed integration tests for xDFSNamespaceServerConfiguration.
+
 ## 3.2.0.0
 
 - Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Fixed integration tests for xDFSNamespaceServerConfiguration.
+- Fixed xDFSNamespaceServerConfiguration by converting LocalHost to ComputerName
+  instead.
 
 ## 3.2.0.0
 

--- a/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
@@ -57,10 +57,10 @@ function Get-TargetResource
         ) -join '' )
 
     <#
-        The ComputerName will always be localhost unless a good reason can be provided to
-        enable it as a parameter.
+        The ComputerName will always be LocalHost unless a good reason can be provided to
+        enable it as a parameter. The case must be exactly 'LocalHost' - do not change.
     #>
-    $computerName = 'localhost'
+    $computerName = 'LocalHost'
 
     # Get the current DFSN Server Configuration
     $serverConfiguration = Get-DfsnServerConfiguration `
@@ -130,10 +130,10 @@ function Set-TargetResource
         ) -join '' )
 
     <#
-        The ComputerName will always be localhost unless a good reason can be provided to
-        enable it as a parameter.
+        The ComputerName will always be LocalHost unless a good reason can be provided to
+        enable it as a parameter. The case must be exactly 'LocalHost' - do not change.
     #>
-    $computerName = 'localhost'
+    $computerName = 'LocalHost'
 
     # Get the current DFSN Server Configuration
     $serverConfiguration = Get-DfsnServerConfiguration `
@@ -246,10 +246,10 @@ function Test-TargetResource
         ) -join '' )
 
     <#
-        The ComputerName will always be localhost unless a good reason can be provided to
-        enable it as a parameter.
+        The ComputerName will always be LocalHost unless a good reason can be provided to
+        enable it as a parameter. The case must be exactly 'LocalHost' - do not change.
     #>
-    $computerName = 'localhost'
+    $computerName = 'LocalHost'
 
     # Flag to signal whether settings are correct
     [System.Boolean] $desiredConfigurationMatch = $true

--- a/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
@@ -160,7 +160,7 @@ function Set-TargetResource
     {
         # Update any parameters that were identified as different
         $null = Set-DfsnServerConfiguration `
-            -ComputerName $computerName `
+            -ComputerName $ENV:COMPUTERNAME `
             @changeParameters `
             -ErrorAction Stop
 

--- a/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
@@ -56,15 +56,9 @@ function Get-TargetResource
             $($LocalizedData.GettingNamespaceServerConfigurationMessage)
         ) -join '' )
 
-    <#
-        The ComputerName will always be LocalHost unless a good reason can be provided to
-        enable it as a parameter. The case must be exactly 'LocalHost' - do not change.
-    #>
-    $computerName = 'LocalHost'
-
     # Get the current DFSN Server Configuration
     $serverConfiguration = Get-DfsnServerConfiguration `
-        -ComputerName $computerName `
+        -ComputerName $ENV:COMPUTERNAME `
         -ErrorAction Stop
 
     # Generate the return object.
@@ -129,15 +123,9 @@ function Set-TargetResource
             $($LocalizedData.SettingNamespaceServerConfigurationMessage)
         ) -join '' )
 
-    <#
-        The ComputerName will always be LocalHost unless a good reason can be provided to
-        enable it as a parameter. The case must be exactly 'LocalHost' - do not change.
-    #>
-    $computerName = 'LocalHost'
-
     # Get the current DFSN Server Configuration
     $serverConfiguration = Get-DfsnServerConfiguration `
-        -ComputerName $computerName `
+        -ComputerName $ENV:COMPUTERNAME `
         -ErrorAction Stop
 
     # Generate a list of parameters that will need to be changed.
@@ -245,18 +233,12 @@ function Test-TargetResource
             $($LocalizedData.TestingNamespaceServerConfigurationMessage)
         ) -join '' )
 
-    <#
-        The ComputerName will always be LocalHost unless a good reason can be provided to
-        enable it as a parameter. The case must be exactly 'LocalHost' - do not change.
-    #>
-    $computerName = 'LocalHost'
-
     # Flag to signal whether settings are correct
     [System.Boolean] $desiredConfigurationMatch = $true
 
     # Get the current DFSN Server Configuration
     $serverConfiguration = Get-DfsnServerConfiguration `
-        -ComputerName $computerName `
+        -ComputerName $ENV:COMPUTERNAME `
         -ErrorAction Stop
 
     # Check each parameter

--- a/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
@@ -58,7 +58,7 @@ function Get-TargetResource
 
     # Get the current DFSN Server Configuration
     $serverConfiguration = Get-DfsnServerConfiguration `
-        -ComputerName $ENV:COMPUTERNAME `
+        -ComputerName $env:COMPUTERNAME `
         -ErrorAction Stop
 
     # Generate the return object.
@@ -125,7 +125,7 @@ function Set-TargetResource
 
     # Get the current DFSN Server Configuration
     $serverConfiguration = Get-DfsnServerConfiguration `
-        -ComputerName $ENV:COMPUTERNAME `
+        -ComputerName $env:COMPUTERNAME `
         -ErrorAction Stop
 
     # Generate a list of parameters that will need to be changed.
@@ -160,7 +160,7 @@ function Set-TargetResource
     {
         # Update any parameters that were identified as different
         $null = Set-DfsnServerConfiguration `
-            -ComputerName $ENV:COMPUTERNAME `
+            -ComputerName $env:COMPUTERNAME `
             @changeParameters `
             -ErrorAction Stop
 
@@ -238,7 +238,7 @@ function Test-TargetResource
 
     # Get the current DFSN Server Configuration
     $serverConfiguration = Get-DfsnServerConfiguration `
-        -ComputerName $ENV:COMPUTERNAME `
+        -ComputerName $env:COMPUTERNAME `
         -ErrorAction Stop
 
     # Check each parameter

--- a/Tests/Integration/MSFT_xDFSNamespaceFolder.config.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceFolder.config.ps1
@@ -1,12 +1,12 @@
 $NamespaceRootName = 'IntegrationTestNamespace'
 $NamespaceFolderName = 'TestFolder'
 $NamespaceRoot = @{
-    Path                         = "\\$($ENV:ComputerName)\$NamespaceRootName"
-    TargetPath                   = "\\$($ENV:ComputerName)\$NamespaceRootName"
+    Path                         = "\\$($env:COMPUTERNAME)\$NamespaceRootName"
+    TargetPath                   = "\\$($env:COMPUTERNAME)\$NamespaceRootName"
 }
 $NamespaceFolder = @{
     Path                         = "$($NamespaceRoot.Path)\$NamespaceFolderName"
-    TargetPath                   = "\\$($ENV:ComputerName)\$NamespaceFolderName"
+    TargetPath                   = "\\$($env:COMPUTERNAME)\$NamespaceFolderName"
     Ensure                       = 'Present'
     Description                  = 'Integration test namespace folder'
     EnableInsiteReferrals        = $true

--- a/Tests/Integration/MSFT_xDFSNamespaceRoot.config.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceRoot.config.ps1
@@ -1,7 +1,7 @@
 $NamespaceRootName = 'IntegrationTestNamespace'
 $NamespaceRoot = @{
-    Path                         = "\\$($ENV:ComputerName)\$NamespaceRootName"
-    TargetPath                   = "\\$($ENV:ComputerName)\$NamespaceRootName" 
+    Path                         = "\\$($env:COMPUTERNAME)\$NamespaceRootName"
+    TargetPath                   = "\\$($env:COMPUTERNAME)\$NamespaceRootName" 
     Ensure                       = 'Present'
     Type                         = 'Standalone'
     Description                  = 'Integration test namespace'

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -53,7 +53,7 @@ try
 
     # Backup the existing settings
     $ServerConfigurationBackup = Get-DFSNServerConfiguration `
-        -ComputerName $($ENV:COMPUTERNAME)
+        -ComputerName $($env:COMPUTERNAME)
 
     #region Integration Tests
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
@@ -75,7 +75,7 @@ try
 
         It 'should have set the resource and all the parameters should match' {
             # Get the Rule details
-            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration -ComputerName $ENV:COMPUTERNAME
+            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration -ComputerName $env:COMPUTERNAME
             $NamespaceServerConfigurationNew.LdapTimeoutSec            = $NamespaceServerConfiguration.LdapTimeoutSec
             $NamespaceServerConfigurationNew.SyncIntervalSec           = $NamespaceServerConfiguration.SyncIntervalSec
             $NamespaceServerConfigurationNew.UseFQDN                   = $NamespaceServerConfiguration.UseFQDN
@@ -83,7 +83,7 @@ try
 
         # Clean up
         Set-DFSNServerConfiguration `
-            -ComputerName $ENV:COMPUTERNAME `
+            -ComputerName $env:COMPUTERNAME `
             -LdapTimeoutSec $ServerConfigurationBackup.LdapTimeoutSec `
             -SyncIntervalSec $ServerConfigurationBackup.SyncIntervalSec `
             -UseFQDN $ServerConfigurationBackup.UseFQDN

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -54,6 +54,7 @@ try
     # Backup the existing settings
     $script:ServerConfigurationBackup = Get-DFSNServerConfiguration `
         -ComputerName localhost
+    Write-Verbose -Verbose -Message ($script:ServerConfigurationBackup | Out-String)
 
     #region Integration Tests
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -52,7 +52,7 @@ try
     }
 
     # Backup the existing settings
-    $script:ServerConfigurationBackup = Get-DFSNServerConfiguration `
+    $ServerConfigurationBackup = Get-DFSNServerConfiguration `
         -ComputerName $($ENV:COMPUTERNAME)
 
     #region Integration Tests
@@ -84,9 +84,9 @@ try
         # Clean up
         Set-DFSNServerConfiguration `
             -ComputerName $ENV:COMPUTERNAME `
-            -LdapTimeoutSec $script:ServerConfigurationBackup.LdapTimeoutSec `
-            -SyncIntervalSec $script:ServerConfigurationBackup.SyncIntervalSec `
-            -UseFQDN $script:ServerConfigurationBackup.UseFQDN
+            -LdapTimeoutSec $ServerConfigurationBackup.LdapTimeoutSec `
+            -SyncIntervalSec $ServerConfigurationBackup.SyncIntervalSec `
+            -UseFQDN $ServerConfigurationBackup.UseFQDN
     }
     #endregion
 }

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -53,7 +53,7 @@ try
 
     # Backup the existing settings
     $script:ServerConfigurationBackup = Get-DFSNServerConfiguration `
-        -ComputerName 'LocalHost'
+        -ComputerName $ENV:COMPUTERNAME
 
     #region Integration Tests
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
@@ -75,7 +75,7 @@ try
 
         It 'should have set the resource and all the parameters should match' {
             # Get the Rule details
-            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration -ComputerName 'LocalHost'
+            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration -ComputerName $ENV:COMPUTERNAME
             $NamespaceServerConfigurationNew.LdapTimeoutSec            = $NamespaceServerConfiguration.LdapTimeoutSec
             $NamespaceServerConfigurationNew.SyncIntervalSec           = $NamespaceServerConfiguration.SyncIntervalSec
             $NamespaceServerConfigurationNew.UseFQDN                   = $NamespaceServerConfiguration.UseFQDN
@@ -83,7 +83,7 @@ try
 
         # Clean up
         Set-DFSNServerConfiguration `
-            -ComputerName 'LocalHost' `
+            -ComputerName $ENV:COMPUTERNAME `
             -LdapTimeoutSec $script:ServerConfigurationBackup.LdapTimeoutSec `
             -SyncIntervalSec $script:ServerConfigurationBackup.SyncIntervalSec `
             -UseFQDN $script:ServerConfigurationBackup.UseFQDN

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -53,7 +53,7 @@ try
 
     # Backup the existing settings
     $script:ServerConfigurationBackup = Get-DFSNServerConfiguration `
-        -ComputerName $ENV:COMPUTERNAME
+        -ComputerName 'LocalHost'
 
     #region Integration Tests
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
@@ -75,7 +75,7 @@ try
 
         It 'should have set the resource and all the parameters should match' {
             # Get the Rule details
-            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration -ComputerName $ENV:COMPUTERNAME
+            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration -ComputerName 'LocalHost'
             $NamespaceServerConfigurationNew.LdapTimeoutSec            = $NamespaceServerConfiguration.LdapTimeoutSec
             $NamespaceServerConfigurationNew.SyncIntervalSec           = $NamespaceServerConfiguration.SyncIntervalSec
             $NamespaceServerConfigurationNew.UseFQDN                   = $NamespaceServerConfiguration.UseFQDN
@@ -83,7 +83,7 @@ try
 
         # Clean up
         Set-DFSNServerConfiguration `
-            -ComputerName $ENV:COMPUTERNAME `
+            -ComputerName 'LocalHost' `
             -LdapTimeoutSec $script:ServerConfigurationBackup.LdapTimeoutSec `
             -SyncIntervalSec $script:ServerConfigurationBackup.SyncIntervalSec `
             -UseFQDN $script:ServerConfigurationBackup.UseFQDN

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -52,9 +52,8 @@ try
     }
 
     # Backup the existing settings
-    $script:ServerConfigurationBackup = Get-DFSNServerConfiguration
-
-    Write-Verbose -Verbose -Message ($script:ServerConfigurationBackup | Out-String)
+    $script:ServerConfigurationBackup = Get-DFSNServerConfiguration `
+        -ComputerName $ENV:COMPUTERNAME
 
     #region Integration Tests
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
@@ -76,7 +75,7 @@ try
 
         It 'should have set the resource and all the parameters should match' {
             # Get the Rule details
-            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration #-ComputerName localhost
+            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration -ComputerName $ENV:COMPUTERNAME
             $NamespaceServerConfigurationNew.LdapTimeoutSec            = $NamespaceServerConfiguration.LdapTimeoutSec
             $NamespaceServerConfigurationNew.SyncIntervalSec           = $NamespaceServerConfiguration.SyncIntervalSec
             $NamespaceServerConfigurationNew.UseFQDN                   = $NamespaceServerConfiguration.UseFQDN
@@ -84,6 +83,7 @@ try
 
         # Clean up
         Set-DFSNServerConfiguration `
+            -ComputerName $ENV:COMPUTERNAME `
             -LdapTimeoutSec $script:ServerConfigurationBackup.LdapTimeoutSec `
             -SyncIntervalSec $script:ServerConfigurationBackup.SyncIntervalSec `
             -UseFQDN $script:ServerConfigurationBackup.UseFQDN

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -53,7 +53,7 @@ try
 
     # Backup the existing settings
     $script:ServerConfigurationBackup = Get-DFSNServerConfiguration `
-        -ComputerName $ENV:COMPUTERNAME
+        -ComputerName $($ENV:COMPUTERNAME)
 
     #region Integration Tests
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -52,7 +52,7 @@ try
     }
 
     # Backup the existing settings
-    $ServerConfigurationBackup = Get-DFSNServerConfiguration `
+    $script:ServerConfigurationBackup = Get-DFSNServerConfiguration `
         -ComputerName localhost
 
     #region Integration Tests
@@ -84,9 +84,9 @@ try
         # Clean up
         Set-DFSNServerConfiguration `
             -ComputerName localhost `
-            -LdapTimeoutSec $ServerConfigurationBackup.LdapTimeoutSec `
-            -SyncIntervalSec $ServerConfigurationBackup.SyncIntervalSec `
-            -UseFQDN $ServerConfigurationBackup.UseFQDN
+            -LdapTimeoutSec $script:ServerConfigurationBackup.LdapTimeoutSec `
+            -SyncIntervalSec $script:ServerConfigurationBackup.SyncIntervalSec `
+            -UseFQDN $script:ServerConfigurationBackup.UseFQDN
     }
     #endregion
 }

--- a/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDFSNamespaceServerConfiguration.Integration.Tests.ps1
@@ -52,8 +52,8 @@ try
     }
 
     # Backup the existing settings
-    $script:ServerConfigurationBackup = Get-DFSNServerConfiguration `
-        -ComputerName localhost
+    $script:ServerConfigurationBackup = Get-DFSNServerConfiguration
+
     Write-Verbose -Verbose -Message ($script:ServerConfigurationBackup | Out-String)
 
     #region Integration Tests
@@ -76,7 +76,7 @@ try
 
         It 'should have set the resource and all the parameters should match' {
             # Get the Rule details
-            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration -ComputerName localhost
+            $NamespaceServerConfigurationNew = Get-DfsnServerConfiguration #-ComputerName localhost
             $NamespaceServerConfigurationNew.LdapTimeoutSec            = $NamespaceServerConfiguration.LdapTimeoutSec
             $NamespaceServerConfigurationNew.SyncIntervalSec           = $NamespaceServerConfiguration.SyncIntervalSec
             $NamespaceServerConfigurationNew.UseFQDN                   = $NamespaceServerConfiguration.UseFQDN
@@ -84,7 +84,6 @@ try
 
         # Clean up
         Set-DFSNServerConfiguration `
-            -ComputerName localhost `
             -LdapTimeoutSec $script:ServerConfigurationBackup.LdapTimeoutSec `
             -SyncIntervalSec $script:ServerConfigurationBackup.SyncIntervalSec `
             -UseFQDN $script:ServerConfigurationBackup.UseFQDN


### PR DESCRIPTION
This was caused by the change from 'LocalHost' to 'localhost'. It appears that the case of 'LocalHost' matters for the *-DfsnServerConfiguration -ComputerName parameter. 

To prevent this sort of problem in future, the ComputerName parameter is changed over to $ENV:COMPUTERNAME instead.

@johlju or @mbreakey3  - is there any chance you could review this for me? It should be fairly straight forward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdfs/32)
<!-- Reviewable:end -->
