### PR TITLE
Prevent ResourceHelper and Common cmdlets from being exported - Fixes #33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fixed xDFSNamespaceServerConfiguration by converting LocalHost to ComputerName
   instead.
+- Added integration test to test for conflicts with other common resource kit modules.
+- Prevented ResourceHelper and Common module cmdlets from being exported to resolve
+  conflicts with other resource modules.
 
 ## 3.2.0.0
 

--- a/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceFolder/MSFT_xDFSNamespaceFolder.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceFolder/MSFT_xDFSNamespaceFolder.psm1
@@ -1,7 +1,9 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xDFS.psd1')
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'DFSDsc.ResourceHelper' `
+                                                     -ChildPath 'DFSDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceRoot/MSFT_xDFSNamespaceRoot.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceRoot/MSFT_xDFSNamespaceRoot.psm1
@@ -1,7 +1,9 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xDFS.psd1')
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'DFSDsc.ResourceHelper' `
+                                                     -ChildPath 'DFSDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSNamespaceServerConfiguration/MSFT_xDFSNamespaceServerConfiguration.psm1
@@ -1,7 +1,9 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xDFS.psd1')
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'DFSDsc.ResourceHelper' `
+                                                     -ChildPath 'DFSDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xDFS/DSCResources/MSFT_xDFSReplicationGroup/MSFT_xDFSReplicationGroup.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSReplicationGroup/MSFT_xDFSReplicationGroup.psm1
@@ -1,7 +1,9 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xDFS.psd1')
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'DFSDsc.ResourceHelper' `
+                                                     -ChildPath 'DFSDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xDFS/DSCResources/MSFT_xDFSReplicationGroupConnection/MSFT_xDFSReplicationGroupConnection.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSReplicationGroupConnection/MSFT_xDFSReplicationGroupConnection.psm1
@@ -1,7 +1,9 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xDFS.psd1')
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'DFSDsc.ResourceHelper' `
+                                                     -ChildPath 'DFSDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xDFS/DSCResources/MSFT_xDFSReplicationGroupFolder/MSFT_xDFSReplicationGroupFolder.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSReplicationGroupFolder/MSFT_xDFSReplicationGroupFolder.psm1
@@ -1,7 +1,9 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xDFS.psd1')
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'DFSDsc.ResourceHelper' `
+                                                     -ChildPath 'DFSDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xDFS/DSCResources/MSFT_xDFSReplicationGroupMembership/MSFT_xDFSReplicationGroupMembership.psm1
+++ b/Modules/xDFS/DSCResources/MSFT_xDFSReplicationGroupMembership/MSFT_xDFSReplicationGroupMembership.psm1
@@ -1,7 +1,9 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xDFS.psd1')
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'DFSDsc.ResourceHelper' `
+                                                     -ChildPath 'DFSDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xDFS/xDFS.psd1
+++ b/Modules/xDFS/xDFS.psd1
@@ -27,7 +27,7 @@
     ProcessorArchitecture = 'None'
 
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-    NestedModules = @('Modules\DFSDsc.ResourceHelper\DFSDsc.ResourceHelper.psm1')
+    # NestedModules = @()
 
     # Functions to export from this module
     FunctionsToExport = '*'

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -34,7 +34,7 @@ try
             It "Should be able to install DSC Resource module '$moduleToTest'" {
                 {
                     Install-Module -Name $moduleToTest -ErrorAction Stop
-                } | Should not throw
+                } | Should Not Throw
             }
         }
     }

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,0 +1,47 @@
+$script:DSCModuleName      = 'xStorage'
+<#
+    These integration tests ensure that exported cmdlets names do not conflict
+    with any other names that are exposed by other common resource kit modules.
+#>
+$script:ModulesToTest = @( 'xNetworking','xComputerManagement','xDFS' )
+
+#region HEADER
+# Integration Test Template Version: 1.1.0
+[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xStorage'
+
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath "$($script:DSCModuleName).psd1") -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName 'All' `
+    -TestType Integration
+
+#endregion
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    Describe "$($script:DSCModuleName)_CommonModuleConflict" {
+        
+        foreach ($moduleToTest in $script:ModulesToTest)
+        {
+            It "Should be able to install DSC Resource module '$moduleToTest'" {
+                {
+                    Install-Module -Name $moduleToTest -ErrorAction Stop
+                } | Should not throw
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,9 +1,9 @@
-$script:DSCModuleName      = 'xStorage'
+$script:DSCModuleName      = 'xDFS'
 <#
     These integration tests ensure that exported cmdlets names do not conflict
     with any other names that are exposed by other common resource kit modules.
 #>
-$script:ModulesToTest = @( 'xNetworking','xComputerManagement','xDFS' )
+$script:ModulesToTest = @( 'xNetworking','xComputerManagement' )
 
 #region HEADER
 # Integration Test Template Version: 1.1.0

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -7,7 +7,7 @@ $script:ModulesToTest = @( 'xNetworking','xComputerManagement' )
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
-[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xStorage'
+[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xDFS'
 
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )


### PR DESCRIPTION
This resolves a high priority issue with newer versions of xNetworking, xCertificate, xStorage and xDFS conflicting with each other because the ResourceHelper cmdlets are being exported due to the way each resource imported them (using the PSD1 nested modules array).

This should be resolved in xNetworking, xStorage and xCertificate as well to ensure no other conflicts.

This also contains a new integration test that will check for any further conflicts between resource modules. At some point it might be possible to move this test into the DSCResource.Tests common tests to provide more comprehensive conflict prevention. However, because the conflicts will potentially be between three different modules the number of modules compared will have to go in over time.

This fixes #33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdfs/34)
<!-- Reviewable:end -->
