### PR TITLE
Prevent unit tests in DSCResource.Tests from running - Fixes #51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
   - ISSUE_TEMPLATE.md
   - PULL_REQUEST_TEMPLATE.md
 - Opted into Common Tests 'Validate Module Files' and 'Validate Script Files'.
-- Converted files with UTF8 with BOM over to UTF8 - fixes [Issue 250](https://github.com/PowerShell/xNetworking/issues/250).
+- Converted files with UTF8 with BOM over to UTF8 - fixes [Issue #47](https://github.com/PowerShell/xDFS/issues/47).
 - Added `Documentation and Examples` section to Readme.md file - see
   [issue #49](https://github.com/PowerShell/xDFS/issues/49).
+- Prevent unit tests from DSCResource.Tests from running during test
+  execution - fixes [Issue #51](https://github.com/PowerShell/xDFS/issues/51).
 
 ## 3.2.0.0
 

--- a/Tests/TestHarness.psm1
+++ b/Tests/TestHarness.psm1
@@ -41,7 +41,21 @@ function Invoke-TestHarness
     # DSC Common Tests
     if ($PSBoundParameters.ContainsKey('DscTestsPath') -eq $true)
     {
-        $testsToRun += @( $DscTestsPath )
+        $getChildItemParameters = @{
+            Path = $DscTestsPath
+            Recurse = $true
+            Filter = '*.Tests.ps1'
+        }
+
+        # Get all tests '*.Tests.ps1'.
+        $commonTestFiles = Get-ChildItem @getChildItemParameters
+
+        # Remove DscResource.Tests unit and integration tests.
+        $commonTestFiles = $commonTestFiles | Where-Object -FilterScript {
+            $_.FullName -notmatch 'DSCResource.Tests\\Tests'
+        }
+
+        $testsToRun += @( $commonTestFiles.FullName )
     }
 
     $results = Invoke-Pester -Script $testsToRun `


### PR DESCRIPTION
**Pull Request (PR) description**
Prevents the unit tests in the DSCResource.Tests helper from being executed during test execution.

@Johlju - would you mind reviewing this when you get a moment. Should be pretty straight forward.

**This Pull Request (PR) fixes the following issues:**
Fixes #51 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdfs/52)
<!-- Reviewable:end -->
