### PR TITLE
DFSReplicationGroup: fix for null compare-object error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added Hub and Spoke replication group example - fixes [Issue #62](https://github.com/PowerShell/DFSDsc/issues/62).
 - Enabled PSSA rule violations to fail build - Fixes [Issue #320](https://github.com/PowerShell/DFSDsc/issues/59).
+- Resolved issue with null values in resource group members or folders - fixes [Issue #27](https://github.com/PowerShell/xDFS/issues/27).
 
 ## 4.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added Hub and Spoke replication group example - fixes [Issue #62](https://github.com/PowerShell/DFSDsc/issues/62).
 - Enabled PSSA rule violations to fail build - Fixes [Issue #320](https://github.com/PowerShell/DFSDsc/issues/59).
-- Resolved issue with null values in resource group members or folders - fixes [Issue #27](https://github.com/PowerShell/xDFS/issues/27).
+- Allow null values in resource group members or folders - fixes [Issue #27](https://github.com/PowerShell/xDFS/issues/27).
 
 ## 4.0.0.0
 

--- a/Modules/DFSDsc/DSCResources/MSFT_DFSReplicationGroup/MSFT_DFSReplicationGroup.psm1
+++ b/Modules/DFSDsc/DSCResources/MSFT_DFSReplicationGroup/MSFT_DFSReplicationGroup.psm1
@@ -626,11 +626,18 @@ function Test-TargetResource
 
             # Compare the Members
             $existingMembers = @((Get-DfsrMember @replicationGroupParameters -ErrorAction Stop).DnsName)
-            if ((Compare-Object `
-                -ReferenceObject $fqdnMembers `
-                -DifferenceObject $existingMembers).Count -ne 0)
+            <#
+                check for null values before using compare-object
+                if one is null but not both then report difference
+                if neither are null then compare values
+            #>
+            if ([String]::IsNullOrEmpty($existingMembers) -and [String]::IsNullOrEmpty($fqdnMembers))
             {
-                # There is a member different of some kind.
+                # both are null so no difference found
+            }
+            elseif ([String]::IsNullOrEmpty($existingMembers) -xor [String]::IsNullOrEmpty($fqdnMembers))
+            {
+                # There is a member difference of some kind.
                 Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
                     $($LocalizedData.ReplicationGroupMembersNeedUpdateMessage) `
@@ -638,16 +645,39 @@ function Test-TargetResource
                     ) -join '' )
 
                 $desiredConfigurationMatch = $false
-            } # if
+            }
+            else
+            {
+                # neither variables are null so it's safe to use compare-object
+                if ((Compare-Object `
+                    -ReferenceObject $fqdnMembers `
+                    -DifferenceObject $existingMembers).Count -ne 0)
+                {
+                    # There is a member difference of some kind.
+                    Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($LocalizedData.ReplicationGroupMembersNeedUpdateMessage) `
+                            -f $GroupName
+                        ) -join '' )
+
+                    $desiredConfigurationMatch = $false
+                } # if
+            }
 
             # Compare the Folders
             $existingFolders = @((Get-DfsReplicatedFolder @replicationGroupParameters -ErrorAction Stop).FolderName)
-
-            if ((Compare-Object `
-                -ReferenceObject $Folders `
-                -DifferenceObject $existingFolders).Count -ne 0)
+            <#
+                check for null values before using compare-object
+                if one is null but not both then report difference
+                if neither are null then compare values
+            #>
+            if ([String]::IsNullOrEmpty($existingFolders) -and [String]::IsNullOrEmpty($Folders))
             {
-                # There is a folder different of some kind.
+                # both are null so no difference found
+            }
+            elseif ([String]::IsNullOrEmpty($existingFolders) -xor [String]::IsNullOrEmpty($Folders))
+            {
+                # There is a folder difference of some kind.
                 Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
                     $($LocalizedData.ReplicationGroupFoldersNeedUpdateMessage) `
@@ -655,8 +685,24 @@ function Test-TargetResource
                     ) -join '' )
 
                 $desiredConfigurationMatch = $false
-            } # if
+            }
+            else
+            {
+                # neither variables are null so it's safe to use compare-object
+                if ((Compare-Object `
+                    -ReferenceObject $Folders `
+                    -DifferenceObject $existingFolders).Count -ne 0)
+                {
+                    # There is a folder difference of some kind.
+                    Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($LocalizedData.ReplicationGroupFoldersNeedUpdateMessage) `
+                            -f $GroupName
+                        ) -join '' )
 
+                    $desiredConfigurationMatch = $false
+                } # if
+            }
             # Get the content paths (if any were passed in the array)
             if ($ContentPaths)
             {

--- a/Tests/Unit/MSFT_DFSReplicationGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_DFSReplicationGroup.Tests.ps1
@@ -96,6 +96,26 @@ try
             DomainName = 'contoso.com'
         }
 
+        $replicationGroupNullMembers = [PSObject]@{
+            GroupName = 'Test Group'
+            Ensure = 'Present'
+            Description = 'Test Description'
+            Members = $Null
+            Folders = @('Folder1','Folder2')
+            Topology = 'Manual'
+            DomainName = 'contoso.com'
+        }
+
+        $replicationGroupNullFolders = [PSObject]@{
+            GroupName = 'Test Group'
+            Ensure = 'Present'
+            Description = 'Test Description'
+            Members = @('FileServer1.contoso.com','FileServer2')
+            Folders = $Null
+            Topology = 'Manual'
+            DomainName = 'contoso.com'
+        }
+
         $replicationGroupConnections = @(
             [PSObject]@{
                 GroupName = 'Test Group'
@@ -977,6 +997,40 @@ try
                 }
             }
 
+            Context 'Replication Group exists but no members passed in' {
+                Mock Get-DfsReplicationGroup -MockWith { @($mockReplicationGroup) }
+                Mock Get-DfsrMember -MockWith { return $mockReplicationGroupMember }
+                Mock Get-DfsReplicatedFolder -MockWith { return $mockReplicationGroupFolder }
+
+                It 'Should return false' {
+                    $splat = $replicationGroupNullMembers.Clone()
+                    Test-TargetResource @splat | Should -Be $False
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DfsReplicationGroup -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DfsrMember -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly -Times 1
+                }
+            }
+
+            Context 'Replication Group exists with no members' {
+                Mock Get-DfsReplicationGroup -MockWith { @($mockReplicationGroup) }
+                Mock Get-DfsrMember -MockWith { return $null }
+                Mock Get-DfsReplicatedFolder -MockWith { return $mockReplicationGroupFolder }
+
+                It 'Should return false' {
+                    $splat = $replicationGroupNullMembers.Clone()
+                    Test-TargetResource @splat | Should -Be $True
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DfsReplicationGroup -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DfsrMember -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly -Times 1
+                }
+            }
+
             Context 'Replication Group exists but some Members passed as FQDN' {
                 Mock Get-DfsReplicationGroup -MockWith { @($mockReplicationGroup) }
                 Mock Get-DfsrMember -MockWith { return $mockReplicationGroupMember }
@@ -1065,6 +1119,40 @@ try
                     Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly -Times 1
                 }
             }
+            Context 'Replication Group exists but no folders passed in' {
+                Mock Get-DfsReplicationGroup -MockWith { @($mockReplicationGroup) }
+                Mock Get-DfsrMember -MockWith { return $mockReplicationGroupMember }
+                Mock Get-DfsReplicatedFolder -MockWith { return $mockReplicationGroupFolder }
+
+                It 'Should return false' {
+                    $splat = $replicationGroupNullFolders.Clone()
+                    Test-TargetResource @splat | Should -Be $False
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DfsReplicationGroup -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DfsrMember -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly -Times 1
+                }
+            }
+
+            Context 'Replication Group exists with no folders' {
+                Mock Get-DfsReplicationGroup -MockWith { @($mockReplicationGroup) }
+                Mock Get-DfsrMember -MockWith { return $mockReplicationGroupMember }
+                Mock Get-DfsReplicatedFolder -MockWith { return $null }
+
+                It 'Should return false' {
+                    $splat = $replicationGroupNullFolders.Clone()
+                    Test-TargetResource @splat | Should -Be $True
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DfsReplicationGroup -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DfsrMember -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DfsReplicatedFolder -Exactly -Times 1
+                }
+            }
+
 
             Context 'Replication Group exists but should not' {
                 Mock Get-DfsReplicationGroup -MockWith { @($mockReplicationGroup) }

--- a/Tests/Unit/MSFT_DFSReplicationGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_DFSReplicationGroup.Tests.ps1
@@ -1019,7 +1019,7 @@ try
                 Mock Get-DfsrMember -MockWith { return $null }
                 Mock Get-DfsReplicatedFolder -MockWith { return $mockReplicationGroupFolder }
 
-                It 'Should return false' {
+                It 'Should return true' {
                     $splat = $replicationGroupNullMembers.Clone()
                     Test-TargetResource @splat | Should -Be $True
                 }
@@ -1141,7 +1141,7 @@ try
                 Mock Get-DfsrMember -MockWith { return $mockReplicationGroupMember }
                 Mock Get-DfsReplicatedFolder -MockWith { return $null }
 
-                It 'Should return false' {
+                It 'Should return true' {
                     $splat = $replicationGroupNullFolders.Clone()
                     Test-TargetResource @splat | Should -Be $True
                 }


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please prefix the PR title with the resource name, i.e. 'DFSNamespaceFolder: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: DFSNamespaceFolder: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
Add section to check for null values in existing member list or proposed member list before using compare-object.  Also added same logic to the comparison of existing and proposed folder list.

**This Pull Request (PR) fixes the following issues:**
Fixes #27 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dfsdsc/63)
<!-- Reviewable:end -->
