### PR TITLE
DFSNamespaceRoot, DFSNamespaceFolder - Support for setting the root / folder State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added support for setting the state of the namespace root (State)
 - DFSNamespaceFolder
   - Added support for setting the state of the namespace folder (State)
+- Updated out of date README.MD.
 
 ## [5.0.1] - 2023-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - DFSNamespaceRoot
   - Added support for setting the state of the namespace root (State)
 - DFSNamespaceFolder
   - Added support for setting the state of the namespace folder (State)
+ 
+### Fixed
+
 - Updated out of date README.MD.
 
 ## [5.0.1] - 2023-09-07
+
+### Fixed
 
 - DFSDsc
   - Removed the pipeline files `build.psd1` as it is no longer needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - DFSNamespaceRoot
-  - Added support for setting the state of the namespace root (Status)
+  - Added support for setting the state of the namespace root (State)
 - DFSNamespaceFolder
-  - Added support for setting the state of the namespace folder (Status)
+  - Added support for setting the state of the namespace folder (State)
 
 ## [5.0.1] - 2023-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- DFSNamespaceRoot
+  - Added support for setting the state of the namespace root (Status)
+- DFSNamespaceFolder
+  - Added support for setting the state of the namespace folder (Status)
+
 ## [5.0.1] - 2023-09-07
 
 - DFSDsc
   - Removed the pipeline files `build.psd1` as it is no longer needed.
-  
+
 ## [5.0.0] - 2023-09-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - DFSNamespaceRoot
-  - Added support for setting the state of the namespace root (State)
+  - Added support for setting the state of the namespace root (State).
 - DFSNamespaceFolder
-  - Added support for setting the state of the namespace folder (State)
+  - Added support for setting the state of the namespace folder (State).
 - DFSNamespaceServerConfiguration
-  - Added support for setting EnableSiteCostedReferrals, EnableInsiteReferrals and PreferLogonDC on a DFS namespace server
- 
+  - Added support for setting EnableSiteCostedReferrals, EnableInsiteReferrals and PreferLogonDC on a DFS namespace server.
+
 ### Fixed
 
+- DFSNamespaceRoot
+  - State and TargetState are only set to 'Online' when specifically passed in the configuration.
+- DFSNamespaceFolder
+  - State and TargetState are only set to 'Online' when specifically passed in the configuration.
 - Updated out of date README.MD.
 
 ## [5.0.1] - 2023-09-07

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
       - job: Package_Module
         displayName: 'Package Module'
         pool:
-          vmImage: 'ubuntu-20.04'
+          vmImage: 'windows-latest'
         steps:
           - pwsh: |
               dotnet tool install --global GitVersion.Tool

--- a/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.psm1
+++ b/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.psm1
@@ -21,6 +21,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
     .PARAMETER TargetState
     Specifies the state of the DFS namespace folder target.
+
+    .PARAMETER State
+    Specifies the state of the DFS namespace folder.
 #>
 function Get-TargetResource
 {
@@ -44,7 +47,12 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $TargetState = 'Online'
+        $TargetState = 'Online',
+
+        [Parameter()]
+        [ValidateSet('Offline','Online')]
+        [System.String]
+        $State = 'Online'
     )
 
     Write-Verbose -Message ( @(
@@ -159,6 +167,9 @@ function Get-TargetResource
 
     .PARAMETER ReferralPriorityRank
     Specifies the priority rank, as an integer, for a root target of the DFS namespace.
+
+    .PARAMETER State
+    Specifies the state of the DFS namespace folder.
 #>
 function Set-TargetResource
 {
@@ -206,7 +217,12 @@ function Set-TargetResource
 
         [Parameter()]
         [System.UInt32]
-        $ReferralPriorityRank
+        $ReferralPriorityRank,
+
+        [Parameter()]
+        [ValidateSet('Offline','Online')]
+        [System.String]
+        $State = 'Online'
     )
 
     Write-Verbose -Message ( @(
@@ -228,8 +244,16 @@ function Set-TargetResource
             [System.Boolean] $folderChange = $false
 
             # The Folder properties that will be updated
-            $folderProperties = @{
-                State = 'Online'
+            $folderProperties = @{}
+
+            # Check the target properties
+            if (($State) `
+                -and ($folder.State -ne $State))
+            {
+                $folderProperties += @{
+                    State = $State
+                }
+                $folderChange = $true
             }
 
             if (($Description) `
@@ -445,6 +469,9 @@ function Set-TargetResource
 
     .PARAMETER ReferralPriorityRank
     Specifies the priority rank, as an integer, for a root target of the DFS namespace.
+
+    .PARAMETER State
+    Specifies the state of the DFS namespace folder.
 #>
 function Test-TargetResource
 {
@@ -493,7 +520,12 @@ function Test-TargetResource
 
         [Parameter()]
         [System.UInt32]
-        $ReferralPriorityRank
+        $ReferralPriorityRank,
+
+        [Parameter()]
+        [ValidateSet('Offline','Online')]
+        [System.String]
+        $State = 'Online'
     )
 
     Write-Verbose -Message ( @(
@@ -517,6 +549,17 @@ function Test-TargetResource
             # The Namespace Folder exists and should
 
             # Check the Namespace parameters
+            if (($State) `
+                -and ($folder.State -ne $State))
+            {
+                Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.NamespaceFolderParameterNeedsUpdateMessage) `
+                            -f $Path,'State'
+                    ) -join '' )
+                $desiredConfigurationMatch = $false
+            }
+
             if (($Description) `
                 -and ($folder.Description -ne $Description))
             {

--- a/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.psm1
+++ b/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.psm1
@@ -176,7 +176,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $TargetState = 'Online',
+        $TargetState,
 
         [Parameter()]
         [System.String]
@@ -206,7 +206,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $State = 'Online'
+        $State
     )
 
     Write-Verbose -Message ( @(
@@ -479,7 +479,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $TargetState = 'Online',
+        $TargetState,
 
         [Parameter()]
         [System.String]
@@ -509,7 +509,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $State = 'Online'
+        $State
     )
 
     Write-Verbose -Message ( @(

--- a/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.psm1
+++ b/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.psm1
@@ -18,12 +18,6 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
     .PARAMETER Ensure
     Specifies if the DFS Namespace root should exist.
-
-    .PARAMETER TargetState
-    Specifies the state of the DFS namespace folder target.
-
-    .PARAMETER State
-    Specifies the state of the DFS namespace folder.
 #>
 function Get-TargetResource
 {
@@ -42,17 +36,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present','Absent')]
         [System.String]
-        $Ensure = 'Present',
-
-        [Parameter()]
-        [ValidateSet('Offline','Online')]
-        [System.String]
-        $TargetState = 'Online',
-
-        [Parameter()]
-        [ValidateSet('Offline','Online')]
-        [System.String]
-        $State = 'Online'
+        $Ensure = 'Present'
     )
 
     Write-Verbose -Message ( @(

--- a/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.schema.mof
+++ b/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.schema.mof
@@ -11,5 +11,5 @@ class DSC_DFSNamespaceFolder : OMI_BaseResource
     [Write, Description("Specifies the target priority class for a DFS namespace root."), ValueMap{"Global-High","SiteCost-High","SiteCost-Normal","SiteCost-Low","Global-Low"}, Values{"Global-High","SiteCost-High","SiteCost-Normal","SiteCost-Low","Global-Low"}] String ReferralPriorityClass;
     [Write, Description("Specifies the priority rank, as an integer, for a root target of the DFS namespace.")] Uint32 ReferralPriorityRank;
     [Write, Description("Specifies a TTL interval, in seconds, for referrals.")] Uint32 TimeToLiveSec;
-    [Write], Description("Specifies the state of the DFS namespace folder."), ValueMap{"Offline","Online"}, Values{"Offline","Online"}] String State;
+    [Write, Description("Specifies the state of the DFS namespace folder."), ValueMap{"Offline","Online"}, Values{"Offline","Online"}] String State;
 };

--- a/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.schema.mof
+++ b/source/DSCResources/DSC_DFSNamespaceFolder/DSC_DFSNamespaceFolder.schema.mof
@@ -11,5 +11,5 @@ class DSC_DFSNamespaceFolder : OMI_BaseResource
     [Write, Description("Specifies the target priority class for a DFS namespace root."), ValueMap{"Global-High","SiteCost-High","SiteCost-Normal","SiteCost-Low","Global-Low"}, Values{"Global-High","SiteCost-High","SiteCost-Normal","SiteCost-Low","Global-Low"}] String ReferralPriorityClass;
     [Write, Description("Specifies the priority rank, as an integer, for a root target of the DFS namespace.")] Uint32 ReferralPriorityRank;
     [Write, Description("Specifies a TTL interval, in seconds, for referrals.")] Uint32 TimeToLiveSec;
-    [Read] String State;
+    [Write], Description("Specifies the state of the DFS namespace folder."), ValueMap{"Offline","Online"}, Values{"Offline","Online"}] String State;
 };

--- a/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.psm1
+++ b/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.psm1
@@ -200,7 +200,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $TargetState = 'Online',
+        $TargetState,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Standalone','DomainV1','DomainV2')]
@@ -247,7 +247,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $State = 'Online'
+        $State
     )
 
     Write-Verbose -Message ( @(
@@ -560,7 +560,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $TargetState = 'Online',
+        $TargetState,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Standalone','DomainV1','DomainV2')]
@@ -607,7 +607,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Offline','Online')]
         [System.String]
-        $State = 'Online'
+        $State
     )
 
     Write-Verbose -Message ( @(

--- a/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.psm1
+++ b/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.psm1
@@ -286,8 +286,6 @@ function Set-TargetResource
 
             # The root properties that will be updated
             $rootProperties = @{}
-                State = 'Online'
-            }
 
             # Check the target properties
             if (($State) `

--- a/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.psm1
+++ b/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.psm1
@@ -19,14 +19,8 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER Ensure
     Specifies if the DFS Namespace root should exist.
 
-    .PARAMETER TargetState
-    Specifies the state of the DFS namespace root target.
-
     .PARAMETER Type
     Specifies the type of a DFS namespace as a Type object.
-
-    .PARAMETER State
-    Specifies the state of the DFS namespace root.
 #>
 function Get-TargetResource
 {
@@ -47,20 +41,10 @@ function Get-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [Parameter()]
-        [ValidateSet('Offline','Online')]
-        [System.String]
-        $TargetState = 'Online',
-
         [Parameter(Mandatory = $true)]
         [ValidateSet('Standalone','DomainV1','DomainV2')]
         [System.String]
-        $Type,
-
-        [Parameter()]
-        [ValidateSet('Offline','Online')]
-        [System.String]
-        $State = 'Online'
+        $Type
     )
 
     Write-Verbose -Message ( @(

--- a/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.psm1
+++ b/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.psm1
@@ -24,6 +24,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
     .PARAMETER Type
     Specifies the type of a DFS namespace as a Type object.
+
+    .PARAMETER State
+    Specifies the state of the DFS namespace root.
 #>
 function Get-TargetResource
 {
@@ -52,7 +55,12 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateSet('Standalone','DomainV1','DomainV2')]
         [System.String]
-        $Type
+        $Type,
+
+        [Parameter()]
+        [ValidateSet('Offline','Online')]
+        [System.String]
+        $State = 'Online'
     )
 
     Write-Verbose -Message ( @(
@@ -183,6 +191,9 @@ function Get-TargetResource
 
     .PARAMETER ReferralPriorityRank
     Specifies the priority rank, as an integer, for a root target of the DFS namespace.
+
+    .PARAMETER State
+    Specifies the state of the DFS namespace root.
 #>
 function Set-TargetResource
 {
@@ -247,7 +258,12 @@ function Set-TargetResource
 
         [Parameter()]
         [System.UInt32]
-        $ReferralPriorityRank
+        $ReferralPriorityRank,
+
+        [Parameter()]
+        [ValidateSet('Offline','Online')]
+        [System.String]
+        $State = 'Online'
     )
 
     Write-Verbose -Message ( @(
@@ -269,9 +285,19 @@ function Set-TargetResource
             [System.Boolean] $rootChange = $false
 
             # The root properties that will be updated
-            $rootProperties = @{
+            $rootProperties = @{}
                 State = 'Online'
             }
+
+            # Check the target properties
+            if (($State) `
+                -and ($root.State -ne $State))
+            {
+                $rootProperties += @{
+                    State = $State
+                }
+                $rootChange = $true
+            } # if
 
             if (($Description) `
                 -and ($root.Description -ne $Description))
@@ -526,6 +552,9 @@ function Set-TargetResource
 
     .PARAMETER ReferralPriorityRank
     Specifies the priority rank, as an integer, for a root target of the DFS namespace.
+
+    .PARAMETER State
+    Specifies the state of the DFS namespace root.
 #>
 function Test-TargetResource
 {
@@ -591,7 +620,12 @@ function Test-TargetResource
 
         [Parameter()]
         [System.UInt32]
-        $ReferralPriorityRank
+        $ReferralPriorityRank,
+
+        [Parameter()]
+        [ValidateSet('Offline','Online')]
+        [System.String]
+        $State = 'Online'
     )
 
     Write-Verbose -Message ( @(
@@ -625,6 +659,18 @@ function Test-TargetResource
             } # if
 
             # Check the Namespace parameters
+            if (($State) `
+                -and ($root.State -ne $State))
+            {
+                Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.NamespaceRootParameterNeedsUpdateMessage) `
+                        -f $Type,$Path,'State'
+                    ) -join '' )
+
+                $desiredConfigurationMatch = $false
+            } # if
+
             if (($Description) `
                 -and ($root.Description -ne $Description))
             {

--- a/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.schema.mof
+++ b/source/DSCResources/DSC_DFSNamespaceRoot/DSC_DFSNamespaceRoot.schema.mof
@@ -15,5 +15,5 @@ class DSC_DFSNamespaceRoot : OMI_BaseResource
     [Write, Description("Specifies the target priority class for a DFS namespace root."), ValueMap{"Global-High","SiteCost-High","SiteCost-Normal","SiteCost-Low","Global-Low"}, Values{"Global-High","SiteCost-High","SiteCost-Normal","SiteCost-Low","Global-Low"}] String ReferralPriorityClass;
     [Write, Description("Specifies the priority rank, as an integer, for a root target of the DFS namespace.")] Uint32 ReferralPriorityRank;
     [Write, Description("Specifies a TTL interval, in seconds, for referrals.")] Uint32 TimeToLiveSec;
-    [Read] String State;
+    [Write, Description("Specifies the state of the DFS namespace root."), ValueMap{"Offline","Online"}, Values{"Offline","Online"}] String State;
 };

--- a/source/Examples/Resources/DFSNamespaceFolder/1-DFSNamespaceFolder_Domain_MultipleTarget_Config.ps1
+++ b/source/Examples/Resources/DFSNamespaceFolder/1-DFSNamespaceFolder_Domain_MultipleTarget_Config.ps1
@@ -57,6 +57,7 @@ Configuration DFSNamespaceFolder_Domain_MultipleTarget_Config
         DFSNamespaceRoot DFSNamespaceRoot_Domain_Software_CA
         {
             Path                 = '\\contoso.com\software'
+            State                = 'Online'
             TargetPath           = '\\ca-fileserver\software'
             Ensure               = 'Present'
             Type                 = 'DomainV2'
@@ -67,6 +68,7 @@ Configuration DFSNamespaceFolder_Domain_MultipleTarget_Config
         DFSNamespaceRoot DFSNamespaceRoot_Domain_Software_MA
         {
             Path                 = '\\contoso.com\software'
+            State                = 'Online'
             TargetPath           = '\\ma-fileserver\software'
             Ensure               = 'Present'
             Type                 = 'DomainV2'
@@ -77,6 +79,7 @@ Configuration DFSNamespaceFolder_Domain_MultipleTarget_Config
         DFSNamespaceRoot DFSNamespaceRoot_Domain_Software_NY_01
         {
             Path                 = '\\contoso.com\software'
+            State                = 'Online'
             TargetPath           = '\\ny-fileserver01\software'
             Ensure               = 'Present'
             Type                 = 'DomainV2'
@@ -87,6 +90,7 @@ Configuration DFSNamespaceFolder_Domain_MultipleTarget_Config
         DFSNamespaceRoot DFSNamespaceRoot_Domain_Software_NY_02
         {
             Path                 = '\\contoso.com\software'
+            State                = 'Online'
             TargetPath           = '\\ny-fileserver02\software'
             TargetState          = 'Offline'
             Ensure               = 'Present'
@@ -99,6 +103,7 @@ Configuration DFSNamespaceFolder_Domain_MultipleTarget_Config
         DFSNamespaceFolder DFSNamespaceFolder_Domain_SoftwareIT_CA
         {
             Path                 = '\\contoso.com\software\it'
+            State                = 'Online'
             TargetPath           = '\\ca-fileserver\it'
             Ensure               = 'Present'
             Description          = 'AD Domain based DFS namespace for storing IT specific software installers'
@@ -108,6 +113,7 @@ Configuration DFSNamespaceFolder_Domain_MultipleTarget_Config
         DFSNamespaceFolder DFSNamespaceFolder_Domain_SoftwareIT_MA
         {
             Path                 = '\\contoso.com\software\it'
+            State                = 'Online'
             TargetPath           = '\\ma-fileserver\it'
             Ensure               = 'Present'
             Description          = 'AD Domain based DFS namespace for storing IT specific software installers'
@@ -117,6 +123,7 @@ Configuration DFSNamespaceFolder_Domain_MultipleTarget_Config
         DFSNamespaceFolder DFSNamespaceFolder_Domain_SoftwareIT_NY_01
         {
             Path                 = '\\contoso.com\software\it'
+            State                = 'Online'
             TargetPath           = '\\ny-fileserver01\it'
             Ensure               = 'Present'
             Description          = 'AD Domain based DFS namespace for storing IT specific software installers'
@@ -126,6 +133,7 @@ Configuration DFSNamespaceFolder_Domain_MultipleTarget_Config
         DFSNamespaceFolder DFSNamespaceFolder_Domain_SoftwareIT_NY_02
         {
             Path                 = '\\contoso.com\software\it'
+            State                = 'Online'
             TargetPath           = '\\ny-fileserver02\it'
             Ensure               = 'Present'
             TargetState          = 'Offline'

--- a/source/Examples/Resources/DFSNamespaceRoot/1-DFSNamespaceRoot_Domain_MultipleTarget_Config.ps1
+++ b/source/Examples/Resources/DFSNamespaceRoot/1-DFSNamespaceRoot_Domain_MultipleTarget_Config.ps1
@@ -56,6 +56,7 @@ Configuration DFSNamespaceRoot_Domain_MultipleTarget_Config
         DFSNamespaceRoot DFSNamespaceRoot_Domain_Software_CA
         {
             Path                 = '\\contoso.com\software'
+            State                = 'Online'
             TargetPath           = '\\ca-fileserver\software'
             Ensure               = 'Present'
             Type                 = 'DomainV2'
@@ -66,6 +67,7 @@ Configuration DFSNamespaceRoot_Domain_MultipleTarget_Config
         DFSNamespaceRoot DFSNamespaceRoot_Domain_Software_MA
         {
             Path                 = '\\contoso.com\software'
+            State                = 'Online'
             TargetPath           = '\\ma-fileserver\software'
             Ensure               = 'Present'
             Type                 = 'DomainV2'
@@ -76,6 +78,7 @@ Configuration DFSNamespaceRoot_Domain_MultipleTarget_Config
         DFSNamespaceRoot DFSNamespaceRoot_Domain_Software_NY
         {
             Path                 = '\\contoso.com\software'
+            State                = 'Online'
             TargetPath           = '\\ny-fileserver\software'
             Ensure               = 'Present'
             Type                 = 'DomainV2'
@@ -87,6 +90,7 @@ Configuration DFSNamespaceRoot_Domain_MultipleTarget_Config
         DFSNamespaceFolder DFSNamespaceFolder_Domain_SoftwareIT_CA
         {
             Path                 = '\\contoso.com\software\it'
+            State                = 'Online'
             TargetPath           = '\\ca-fileserver\it'
             Ensure               = 'Present'
             Description          = 'AD Domain based DFS namespace for storing IT specific software installers'
@@ -96,6 +100,7 @@ Configuration DFSNamespaceRoot_Domain_MultipleTarget_Config
         DFSNamespaceFolder DFSNamespaceFolder_Domain_SoftwareIT_MA
         {
             Path                 = '\\contoso.com\software\it'
+            State                = 'Online'
             TargetPath           = '\\ma-fileserver\it'
             Ensure               = 'Present'
             Description          = 'AD Domain based DFS namespace for storing IT specific software installers'
@@ -105,6 +110,7 @@ Configuration DFSNamespaceRoot_Domain_MultipleTarget_Config
         DFSNamespaceFolder DFSNamespaceFolder_Domain_SoftwareIT_NY_01
         {
             Path                 = '\\contoso.com\software\it'
+            State                = 'Online'
             TargetPath           = '\\ny-fileserver01\it'
             Ensure               = 'Present'
             Description          = 'AD Domain based DFS namespace for storing IT specific software installers'
@@ -114,6 +120,7 @@ Configuration DFSNamespaceRoot_Domain_MultipleTarget_Config
         DFSNamespaceFolder DFSNamespaceFolder_Domain_SoftwareIT_NY02
         {
             Path                 = '\\contoso.com\software\it'
+            State                = 'Online'
             TargetPath           = '\\ny-fileserver02\it'
             Ensure               = 'Present'
             TargetState          = 'Offline'

--- a/tests/Integration/DSC_DFSNamespaceFolder.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DFSNamespaceFolder.Integration.Tests.ps1
@@ -76,6 +76,7 @@ try
                     EnableTargetFailback         = $true
                     ReferralPriorityClass        = 'Global-Low'
                     ReferralPriorityRank         = 10
+                    State                        = 'Online'
                 }
 
                 # Create a SMB share for the Namespace
@@ -124,6 +125,7 @@ try
                                 EnableTargetFailback         = $script:namespaceFolder.EnableTargetFailback
                                 ReferralPriorityClass        = $script:namespaceFolder.ReferralPriorityClass
                                 ReferralPriorityRank         = $script:namespaceFolder.ReferralPriorityRank
+                                State                        = $script:namespaceFolder.State
                             }
                         )
                     }
@@ -150,7 +152,7 @@ try
                 $namespaceFolderNew = Get-DfsnFolder -Path $script:namespaceFolder.Path
                 $namespaceFolderNew.Path                          | Should -Be $script:namespaceFolder.Path
                 $namespaceFolderNew.TimeToLiveSec                 | Should -Be 300
-                $namespaceFolderNew.State                         | Should -Be 'Online'
+                $namespaceFolderNew.State                         | Should -Be $script:namespaceFolder.State
                 $namespaceFolderNew.Description                   | Should -Be $script:namespaceFolder.Description
                 $namespaceFolderNew.NamespacePath                 | Should -Be $script:namespaceFolder.Path
                 $namespaceFolderNew.Flags                         | Should -Be @('Target Failback','Insite Referrals')

--- a/tests/Integration/DSC_DFSNamespaceFolder.config.ps1
+++ b/tests/Integration/DSC_DFSNamespaceFolder.config.ps1
@@ -12,6 +12,7 @@ Configuration DSC_DFSNamespaceFolder_Config {
             EnableTargetFailback         = $Node.EnableTargetFailback
             ReferralPriorityClass        = $Node.ReferralPriorityClass
             ReferralPriorityRank         = $Node.ReferralPriorityRank
+            State                        = $Node.State
         }
     }
 }

--- a/tests/Integration/DSC_DFSNamespaceRoot.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DFSNamespaceRoot.Integration.Tests.ps1
@@ -76,6 +76,7 @@ try
                     EnableTargetFailback         = $true
                     ReferralPriorityClass        = 'Global-Low'
                     ReferralPriorityRank         = 10
+                    State                        = 'Online'
                 }
 
                 # Create a SMB share for the Namespace
@@ -112,6 +113,7 @@ try
                                 EnableTargetFailback         = $script:namespaceRoot.EnableTargetFailback
                                 ReferralPriorityClass        = $script:namespaceRoot.ReferralPriorityClass
                                 ReferralPriorityRank         = $script:namespaceRoot.ReferralPriorityRank
+                                State                        = $script:namespaceRoot.State
                             }
                         )
                     }
@@ -140,7 +142,7 @@ try
                 $namespaceRootNew.Path          | Should -Be $script:namespaceRoot.Path
                 $namespaceRootNew.Type          | Should -Be $script:namespaceRoot.Type
                 $namespaceRootNew.TimeToLiveSec | Should -Be $script:namespaceRoot.TimeToLiveSec
-                $namespaceRootNew.State         | Should -Be 'Online'
+                $namespaceRootNew.State         | Should -Be $script:namespaceRoot.State
                 $namespaceRootNew.Description   | Should -Be $script:namespaceRoot.Description
                 $namespaceRootNew.NamespacePath | Should -Be $script:namespaceRoot.Path
                 $namespaceRootNew.Flags         | Should -Be @('Target Failback','Site Costing','Insite Referrals','AccessBased Enumeration')

--- a/tests/Integration/DSC_DFSNamespaceRoot.config.ps1
+++ b/tests/Integration/DSC_DFSNamespaceRoot.config.ps1
@@ -18,6 +18,7 @@ Configuration DSC_DFSNamespaceRoot_Config {
             EnableTargetFailback         = $Node.EnableTargetFailback
             ReferralPriorityClass        = $Node.ReferralPriorityClass
             ReferralPriorityRank         = $Node.ReferralPriorityRank
+            State                        = $Node.State
         }
     }
 }

--- a/tests/Unit/DSC_DFSNamespaceRoot.Tests.ps1
+++ b/tests/Unit/DSC_DFSNamespaceRoot.Tests.ps1
@@ -80,6 +80,7 @@ try
             EnableTargetFailback         = $true
             ReferralPriorityClass        = 'Global-Low'
             ReferralPriorityRank         = 10
+            State                        = 'Online'
         }
 
         $namespaceSplat = [PSObject]@{
@@ -384,6 +385,29 @@ try
                     {
                         $splat = $namespace.Clone()
                         $splat.EnableTargetFailback = $False
+                        Set-TargetResource @splat
+                    } | Should -Not -Throw
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNRoot -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DFSNRootTarget -Exactly -Times 1
+                    Assert-MockCalled -commandName New-DFSNRoot -Exactly -Times 0
+                    Assert-MockCalled -commandName Set-DFSNRoot -Exactly -Times 1
+                    Assert-MockCalled -commandName New-DfsnRootTarget -Exactly -Times 1
+                    Assert-MockCalled -commandName Set-DfsnRootTarget -Exactly -Times 0
+                    Assert-MockCalled -commandName Remove-DfsnRootTarget -Exactly -Times 0
+                }
+            }
+
+            Context 'Namespace Root exists and should but has a different State' {
+                Mock Get-DFSNRoot -MockWith { $namespaceRoot }
+                Mock Get-DFSNRootTarget
+
+                It 'Should not throw error' {
+                    {
+                        $splat = $namespace.Clone()
+                        $splat.State = 'Offline'
                         Set-TargetResource @splat
                     } | Should -Not -Throw
                 }
@@ -739,6 +763,22 @@ try
                 It 'Should return false' {
                     $splat = $namespace.Clone()
                     $splat.TargetState = 'Offline'
+                    Test-TargetResource @splat | Should -BeFalse
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNRoot -Exactly -Times 1
+                    Assert-MockCalled -commandName Get-DFSNRootTarget -Exactly -Times 1
+                }
+            }
+
+            Context 'Namespace Root exists and should but has a different State' {
+                Mock Get-DFSNRoot -MockWith { $namespaceRoot }
+                Mock Get-DFSNRootTarget
+
+                It 'Should return false' {
+                    $splat = $namespace.Clone()
+                    $splat.State = 'Offline'
                     Test-TargetResource @splat | Should -BeFalse
                 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

This PR allows the 'State' parameter on the DFSNamespaceRoot and DFSNamespaceFolder to be modified as part of a configuration. This allows an entire Root or Folder to be set Online or Offline (as opposed to individual root / folder targets which can already be set Online or Offline using TargetState on both resources.)

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DFSDsc/133)
<!-- Reviewable:end -->
