### PR TITLE
DFSReplicationGroup - update PrimaryMember to write-only but not test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+
  - DFSReplicationGroupMembership
    - Make PrimaryMember write-only when testing resources - fixes [Issue #58](https://github.com/dsccommunity/DFSDsc/issues/58).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+ - DFSReplicationGroupMembership
+   - Make PrimaryMember write-only when testing resources - fixes [Issue #58](https://github.com/dsccommunity/DFSDsc/issues/58).
+
 ## [5.1.0] - 2024-03-02
 
 ### Added

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.psm1
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.psm1
@@ -534,8 +534,8 @@ function Test-TargetResource
                     -f $GroupName,$FolderName,$ComputerName
                 ) -join '' )
 
-            # See https://techcommunity.microsoft.com/t5/storage-at-microsoft/the-primary-member-in-dfs-replication/ba-p/423127
-            # Do not flag as a change required as flag is cleared after initial sync
+            <# See https://techcommunity.microsoft.com/t5/storage-at-microsoft/the-primary-member-in-dfs-replication/ba-p/423127
+            Do not flag as a change required as flag is cleared after initial sync #>
         } # if
 
         # Check the DfsnPath

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.psm1
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.psm1
@@ -534,8 +534,10 @@ function Test-TargetResource
                     -f $GroupName,$FolderName,$ComputerName
                 ) -join '' )
 
-            <# See https://techcommunity.microsoft.com/t5/storage-at-microsoft/the-primary-member-in-dfs-replication/ba-p/423127
-            Do not flag as a change required as flag is cleared after initial sync #>
+            <#
+            See https://techcommunity.microsoft.com/t5/storage-at-microsoft/the-primary-member-in-dfs-replication/ba-p/423127
+            Do not flag as a change required as flag is cleared after initial sync
+            #>
         } # if
 
         # Check the DfsnPath

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.psm1
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.psm1
@@ -167,7 +167,7 @@ function Get-TargetResource
     .PARAMETER PrimaryMember
     Used to configure this as the Primary Member. Every folder must
     have at least one primary member for initial replication to take
-    place.
+    place. Only set during initial creation of membership.
 
     .PARAMETER DfsnPath
     Specify the DFS Namespace folder path of the membership. This value does not affect replication.
@@ -307,7 +307,7 @@ function Set-TargetResource
     .PARAMETER PrimaryMember
     Used to configure this as the Primary Member. Every folder must
     have at least one primary member for initial replication to take
-    place.
+    place. Only set during initial creation of membership.
 
     .PARAMETER DfsnPath
     Specify the DFS Namespace folder path of the membership. This value does not affect replication.
@@ -534,7 +534,8 @@ function Test-TargetResource
                     -f $GroupName,$FolderName,$ComputerName
                 ) -join '' )
 
-            $desiredConfigurationMatch = $false
+            # See https://techcommunity.microsoft.com/t5/storage-at-microsoft/the-primary-member-in-dfs-replication/ba-p/423127
+            # Do not flag as a change required as flag is cleared after initial sync
         } # if
 
         # Check the DfsnPath

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.schema.mof
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.schema.mof
@@ -13,7 +13,7 @@ class DSC_DFSReplicationGroupMembership : OMI_BaseResource
     [Write, Description("The local conflict and deleted path quota size in MB.")] UInt32 ConflictAndDeletedQuotaInMB;
     [Write, Description("Specify if this content path should be read only.")] Boolean ReadOnly;
     [Write, Description("Specify if a member computer deletes files and folders immediately following inbound replication.")] Boolean RemoveDeletedFiles;
-    [Write, Description("Used to configure this as the Primary Member. Every folder must have at least one primary member for initial replication to take place.  Only set during initial creation of membership.")] Boolean PrimaryMember;
+    [Write, Description("Used to configure this as the Primary Member. Every folder must have at least one primary member for initial replication to take place. Only set during initial creation of membership.")] Boolean PrimaryMember;
     [Write, Description("Specify the DFS Namespace folder path of the membership. This value does not affect replication.")] String DfsnPath;
     [Write, Description("The name of the AD Domain the DFS Replication Group this replication group is in.")] String DomainName;
 };

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.schema.mof
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/DSC_DFSReplicationGroupMembership.schema.mof
@@ -13,7 +13,7 @@ class DSC_DFSReplicationGroupMembership : OMI_BaseResource
     [Write, Description("The local conflict and deleted path quota size in MB.")] UInt32 ConflictAndDeletedQuotaInMB;
     [Write, Description("Specify if this content path should be read only.")] Boolean ReadOnly;
     [Write, Description("Specify if a member computer deletes files and folders immediately following inbound replication.")] Boolean RemoveDeletedFiles;
-    [Write, Description("Used to configure this as the Primary Member. Every folder must have at least one primary member for initial replication to take place.")] Boolean PrimaryMember;
+    [Write, Description("Used to configure this as the Primary Member. Every folder must have at least one primary member for initial replication to take place.  Only set during initial creation of membership.")] Boolean PrimaryMember;
     [Write, Description("Specify the DFS Namespace folder path of the membership. This value does not affect replication.")] String DfsnPath;
     [Write, Description("The name of the AD Domain the DFS Replication Group this replication group is in.")] String DomainName;
 };

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/README.md
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/README.md
@@ -6,5 +6,5 @@ Member computer. It can also be used to set additional properties of the Members
 This resource shouldn't be used for folders where the Content Path is set in the
 DFSReplicationGroup.
 
-Note: The PrimaryMember flag is automatically cleared by DFS once an initial
-replication sync takes place, so is not tested by this resource.
+> Note: The PrimaryMember flag is automatically cleared by DFS once an initial
+> replication sync takes place, so is not tested by this resource.

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/README.md
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/README.md
@@ -4,5 +4,7 @@ This resource is used to configure Replication Group Folder Membership. It is
 usually used to set the **ContentPath** for each Replication Group folder on each
 Member computer. It can also be used to set additional properties of the Membership.
 This resource shouldn't be used for folders where the Content Path is set in the
-DFSReplicationGroup. NB The PrimaryMember flag is automatically cleared by DFS once
-an initial replication sync takes place, so is not tested by this resource.
+DFSReplicationGroup.
+
+Note: The PrimaryMember flag is automatically cleared by DFS once an initial
+replication sync takes place, so is not tested by this resource.

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/README.md
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/README.md
@@ -4,4 +4,5 @@ This resource is used to configure Replication Group Folder Membership. It is
 usually used to set the **ContentPath** for each Replication Group folder on each
 Member computer. It can also be used to set additional properties of the Membership.
 This resource shouldn't be used for folders where the Content Path is set in the
-DFSReplicationGroup.
+DFSReplicationGroup. NB The PrimaryMember flag is automatically cleared by DFS once
+an initial replication sync takes place, so is not tested by this resource.

--- a/source/DSCResources/DSC_DFSReplicationGroupMembership/en-US/DSC_DFSReplicationGroupMembership.strings.psd1
+++ b/source/DSCResources/DSC_DFSReplicationGroupMembership/en-US/DSC_DFSReplicationGroupMembership.strings.psd1
@@ -13,6 +13,6 @@ ConvertFrom-StringData @'
     ReplicationGroupMembershipConflictAndDeletedMismatchMessage = DFS Replication Group "{0}" folder "{1}" on "{2}" has incorrect ConflictAndDeletedQuotaInMB. Change required.
     ReplicationGroupMembershipReadOnlyMismatchMessage           = DFS Replication Group "{0}" folder "{1}" on "{2}" has incorrect ReadOnly. Change required.
     ReplicationGroupMembershipRemoveDeletedFilesMismatchMessage = DFS Replication Group "{0}" folder "{1}" on "{2}" has incorrect RemoveDeletedFiles. Change required.
-    ReplicationGroupMembershipPrimaryMemberMismatchMessage      = DFS Replication Group "{0}" folder "{1}" on "{2}" has incorrect PrimaryMember. Change required.
+    ReplicationGroupMembershipPrimaryMemberMismatchMessage      = DFS Replication Group "{0}" folder "{1}" on "{2}" has incorrect PrimaryMember. Ignoring as flag clears after initial sync.
     ReplicationGroupMembershipDfsnPathMismatchMessage           = DFS Replication Group "{0}" folder "{1}" on "{2}" has incorrect DfsnPath. Change required.
 '@

--- a/tests/Unit/DSC_DFSReplicationGroupMembership.Tests.ps1
+++ b/tests/Unit/DSC_DFSReplicationGroupMembership.Tests.ps1
@@ -541,11 +541,12 @@ try
             Context 'Replication group membership exists but has different PrimaryMember' {
                 Mock Get-DfsrMembership -MockWith { return @($mockReplicationGroupMembership) }
 
-                It 'Should return false' {
+                # Return *true* - should not flag as changed required as cleared after initial sync
+                It 'Should return true' {
                     $splat = $replicationGroupMemberships[0].Clone()
                     $splat.Remove('ConflictAndDeletedPath')
                     $splat.PrimaryMember = (-not $splat.PrimaryMember)
-                    Test-TargetResource @splat | Should -BeFalse
+                    Test-TargetResource @splat | Should -BeTrue
                 }
 
                 It 'Should call expected Mocks' {


### PR DESCRIPTION
#### Pull Request (PR) description

Make PrimaryMember a write-only property that should not test

#### This Pull Request (PR) fixes the following issues

- Fixes #58 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DFSDsc/138)
<!-- Reviewable:end -->
